### PR TITLE
better syntax highlighting on jsdoc comments

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -6477,7 +6477,7 @@ of a simple name.  Called before EXPR has a parent node."
           "\\(?:param\\|argument\\)"
           "\\)"
           "\\s-*\\({[^}]+}\\)?"         ; optional type
-          "\\s-*\\([a-zA-Z0-9_$]+\\)?"  ; name
+          "\\s-*\\[?\\([a-zA-Z0-9_$]+\\)?\\]?"  ; name
           "\\>")
   "Matches jsdoc tags with optional type and optional param name.")
 


### PR DESCRIPTION
make the jsdoc highlighting recoginze optional parameters, which have names inside square brackets
