### PR TITLE
Minor fixes

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -11425,7 +11425,7 @@ Some users don't like having warnings/errors reported while they type."
   (interactive)
   (setq js2-mode-show-parse-errors (not js2-mode-show-parse-errors)
         js2-mode-show-strict-warnings (not js2-mode-show-strict-warnings))
-  (if (interactive-p)
+  (if (call-interactively 'interactive)
       (message "warnings and errors %s"
                (if js2-mode-show-parse-errors
                    "enabled"


### PR DESCRIPTION
Hi, I've modified a couple of things to be able to use js2-mode.
1. I've remade js2-treeify because the recursive one failed at compile time because of the max-lisp-eval-depth.
2. I've fixed two warnings caused by the use of save-excursion + set-buffer instead of with-current-buffer
3. Finally, I've fixed a warning caused by the use of interactive-p which is deprecated.

PS: I use Emacs24 from the git mirror.
PPS: I use magnars's repository.
