### PR TITLE
before-save-hook as local variable

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10421,7 +10421,7 @@ If so, we don't ever want to use bounce-indent."
   ;; So it's back to `c-fill-paragraph'.
   (set (make-local-variable 'fill-paragraph-function) #'c-fill-paragraph)
 
-  (set (make-local-variable 'before-save-hook) #'js2-before-save)
+  (add-hook 'before-save-hook #'js2-before-save nil t)
   (set (make-local-variable 'next-error-function) #'js2-next-error)
   (set (make-local-variable 'beginning-of-defun-function) #'js2-beginning-of-defun)
   (set (make-local-variable 'end-of-defun-function) #'js2-end-of-defun)


### PR DESCRIPTION
js2-mode makes `before-save-hook` a buffer-local variable, which prevents any global `before-save-hook` functions from running in javascript buffers (I happen to use [ethan-wspace](https://github.com/glasserc/ethan-wspace) to handle whitespace cleanup for all major modes). The Emacs manual [recommends](http://www.gnu.org/software/emacs/manual/html_node/elisp/Creating-Buffer_002dLocal.html) using `add-hook` with a non-nil `local` argument for buffer-local hooks, so I changed the way `js2-cleanup-whitespace` is hooked.
