### PR TITLE
Consider foo.bar to be a single parameter name in jsdoc comments

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -6479,7 +6479,7 @@ of a simple name.  Called before EXPR has a parent node."
           "\\(?:param\\|argument\\)"
           "\\)"
           "\\s-*\\({[^}]+}\\)?"         ; optional type
-          "\\s-*\\[?\\([a-zA-Z0-9_$]+\\)?\\]?"  ; name
+          "\\s-*\\[?\\([a-zA-Z0-9_$\.]+\\)?\\]?"  ; name
           "\\>")
   "Matches jsdoc tags with optional type and optional param name.")
 


### PR DESCRIPTION
js2-mode nicely highlights jsdoc comments, putting `userinfo` in a different face in comments like this one:

```
 /**
  * @param userInfo Information about the user.
  * @param userInfo.name The name of the user.
  */
```

Unfortunately it doesn't consider `userInfo.name` to be a single parameter (useful when documenting complex parameters, as described at http://code.google.com/p/jsdoc-toolkit/wiki/TagParam).  Changing `js2-jsdoc-param-tag-regexp` to allow a literal `.` character in names fixes this.
