### PR TITLE
show keybindings in the mode description

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10430,7 +10430,7 @@ If so, we don't ever want to use bounce-indent."
 
 ;;;###autoload
 (defun js2-mode ()
-  "Major mode for editing JavaScript code."
+  "Major mode for editing JavaScript code.\n\n\\{js2-mode-map}"
   (interactive)
   (kill-all-local-variables)
   (set-syntax-table js2-mode-syntax-table)


### PR DESCRIPTION
Including the keymap in the description seems to be the convention. I usually use `C-h m` (`describe-mode`) to stumble across cool things major modes can do that I didn't know about. Quickly scanning function names is way easier than quickly scanning a whole manual.
