### PR TITLE
Bind RET to newline-and-indent

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -1165,8 +1165,7 @@ another file, or you've got a potential bug."
     (define-key map (kbd "C-c C-o") #'js2-mode-toggle-element)
     (define-key map (kbd "C-c C-w") #'js2-mode-toggle-warnings-and-errors)
     (define-key map (kbd "C-c C-`") #'js2-next-error)
-	;;回车后要有indent
-	(define-key map (kbd "RET") 'my-return)
+	(define-key map (kbd "RET") 'js2-mode-return)
 
     (define-key map (or (car (where-is-internal #'mark-defun))
                         (kbd "M-C-h"))
@@ -11734,8 +11733,8 @@ it marks the next defun after the ones already marked."
     (unless (js2-ast-root-p fn)
       (narrow-to-region beg (+ beg (js2-node-len fn))))))
 
-;;回车后要有indent
-(defun my-return()
+(defun js2-mode-return ()
+  "Bind RET to newline-and-indent."
   (interactive)
   (newline-and-indent))
 


### PR DESCRIPTION
Bind RET to newline-and-indent, so we don't have to TAB to indent after RET.
