### PR TITLE
Update future reserved keywords list

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -5204,20 +5204,20 @@ into temp buffers."
 The values are default faces to use for highlighting the keywords.")
 
 (defconst js2-reserved-words
-  '(abstract
-    boolean byte
-    char class
-    double
-    enum export extends
-    final float
-    goto
-    implements import int interface
-    long
-    native
-    package private protected public
-    short static super synchronized
-    throws transient
-    volatile))
+  '(class
+    export
+    extends
+    super
+    implements
+    interface
+    package
+    private
+    protected
+    public
+    static)
+  "Keywords reserved for possible future use.
+See section 7.6.1 of the ECMAScript standard, available at
+http://es5.github.io/#x7.6.1")
 
 (defconst js2-keyword-names
   (let ((table (make-hash-table :test 'equal)))


### PR DESCRIPTION
They've changed since the original authoring of js2-mode; this is not the _exact_ list from the spec, as some are already included in js2-keywords (enum, import, yield).

I considered modifying the contents of js2-keywords to also match the spec more exactly, but it was unclear to me what the effects of that would be, so I've left it alone for now.
