### PR TITLE
Fix electric-indent-mode

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10371,8 +10371,7 @@ Selecting an error will jump it to the corresponding source-buffer error.
   (put 'js2-mode 'find-tag-default-function #'js2-mode-find-tag)
 
   (set (make-local-variable 'electric-indent-chars)
-       (append '("{" "}" "(" ")" "[" "]" ":" ";" "," "*")
-               electric-indent-chars))
+       (append "{}()[]:;,*" electric-indent-chars))
   (set (make-local-variable 'electric-layout-rules)
        '((?\; . after) (?\{ . after) (?\} . before)))
 


### PR DESCRIPTION
electric-indent-mode is broken.

electric-indent-mode (electric.el) initially defines electric-indent-chars as follows:

``` elisp
(defvar electric-indent-chars '(?\n)
  "Characters that should cause automatic reindentation.")
```

js-mode (js.el) adds more characters like this:

``` elisp
(set (make-local-variable 'electric-indent-chars)
     (append "{}():;," electric-indent-chars)) ;FIXME: js2-mode adds "[]*".
```

The resulting electric-indent-chars for buffers where js-mode is active:

```
electric-indent-chars is a variable defined in `electric.el'.
Its value is (123 125 40 41 58 59 44 10)
Local in buffer foo.js; global value is (10)
```

`M-x describe-variable` displays the values in ASCII decimal, not exactly sure why.

js2-mode however, appends to electric-indent-chars incorrectly. Loading js2-mode and M-x describe-value electric-indent-chars gives:

```
electric-indent-chars is a variable defined in `electric.el'.
Its value is ("{" "}" "(" ")" "[" "]" ":" ";" "," "*" 10)
Local in buffer foo.js; global value is (10)
```

This doesn't work properly. None of the string values have any effect. E.g. typing "}" should trigger a reindentation, but it doesn't. Only \n (10) works, which is the inital value set by electric.el.

This PR should fix it by appending to the var the same as js-mode does.
