### PR TITLE
Fix parsing of let expressions

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -3302,7 +3302,9 @@ Note that a let declaration such as let x=6, y=7 is a `js2-var-decl-node'."
 
 (defun js2-print-let-node (n i)
   (insert (js2-make-pad i) "let (")
-  (js2-print-ast (js2-let-node-vars n) 0)
+  (let ((p (point)))
+    (js2-print-ast (js2-let-node-vars n) 0)
+    (delete-region p (+ p 4)))
   (insert ") ")
   (js2-print-ast (js2-let-node-body n) i))
 
@@ -8471,10 +8473,11 @@ by `js2-parse-variables'."
                       (js2-let-node-body pn) body
                       (js2-node-type pn) js2-LET))
             ;; let expression
-            (js2-unget-token)
+            (when stmt-p (js2-unget-token))
             (setf body (js2-parse-expr)
                   (js2-node-len pn) (- (js2-node-end body) pos)
                   (js2-let-node-body pn) body))
+          (setf (js2-let-node-vars pn) vars)
           (js2-node-add-children pn vars body))
       (js2-pop-scope))
     pn))

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -121,6 +121,9 @@ the test."
 (js2-deftest-parse for-with-in-operator-in-cond
   "for (var y = 1 ? 0 in [] : false in {}) {\n}")
 
+(js2-deftest-parse let-expression
+  "(let (x = 42) x);")
+
 ;;; Callers of `js2-valid-prop-name-token'
 
 (js2-deftest-parse parse-property-access-when-not-keyword


### PR DESCRIPTION
js2-mode can't parse let expression `(let (x = 42) x)`.
