### PR TITLE
Replace 'labels' with 'cl-labels'.

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10355,12 +10355,12 @@ highlighting features of `js2-mode'."
   (unless (js2-have-errors-p)
     (message "No errors")
     (return-from js2-display-error-list))
-  (labels ((annotate-list
-            (lst type)
-            "Add diagnostic TYPE and line number to errs list"
-            (mapcar (lambda (err)
-                      (list err type (line-number-at-pos (nth 1 err))))
-                    lst)))
+  (cl-labels ((annotate-list
+               (lst type)
+               "Add diagnostic TYPE and line number to errs list"
+               (mapcar (lambda (err)
+                         (list err type (line-number-at-pos (nth 1 err))))
+                       lst)))
     (let* ((srcbuf (current-buffer))
            (errbuf (get-buffer-create "*js-lint*"))
            (errors (annotate-list


### PR DESCRIPTION
Hi,

on Emacs 24.4.50.1 I get a deprecation warning on load for the use of `labels` (vs. `cl-labels`), so this commit replaces the one usage in `js2-mode.el`.

Cheers,
Olof
