### PR TITLE
Add Map, Set, WeakMap & WeakSet symbols

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -102,8 +102,8 @@
 (defvar js2-ecma-262-externs
   (mapcar 'symbol-name
           '(Array Boolean Date Error EvalError Function Infinity JSON
-          Math NaN Number Object RangeError ReferenceError RegExp
-          String SyntaxError TypeError URIError arguments
+          Math Map NaN Number Object RangeError ReferenceError RegExp
+          Set String SyntaxError TypeError URIError WeakMap WeakSet arguments
           decodeURI decodeURIComponent encodeURI
           encodeURIComponent escape eval isFinite isNaN
           parseFloat parseInt undefined unescape))


### PR DESCRIPTION
There are supposed by many browsers already: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Browser_compatibility

I wasn't sure if you want a separate list of symbols for ES6 or not. For now I put them in the existing js2-ecma-262-externs list.
