### PR TITLE
Replace usage of 'cl with 'cl-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ You can also install the latest development version from
 Emacs 22 and 23
 ===============
 
-This version requires Emacs 24. For a backward compatible version,
-check out the branch
+This version requires Emacs 24 and `cl-lib` (either built-in or from GNU ELPA above).
+For a backward compatible version, check out the branch
 [emacs23](https://github.com/mooz/js2-mode/tree/emacs23).
 
 Bugs

--- a/tests/indent.el
+++ b/tests/indent.el
@@ -21,6 +21,7 @@
 
 (require 'ert)
 (require 'js2-mode)
+(require 'cl-lib)
 
 (defun js2-test-indent (content)
   (let ((s (replace-regexp-in-string "^ *|" "" content)))
@@ -31,7 +32,7 @@
       (should (string= s (buffer-substring-no-properties
                           (point-min) (point)))))))
 
-(defmacro* js2-deftest-indent (name content &key bind)
+(cl-defmacro js2-deftest-indent (name content &key bind)
   `(ert-deftest ,(intern (format "js2-%s" name)) ()
      (let ,(append '((js2-basic-offset 2)
                      (js2-pretty-multiline-declarations t)


### PR DESCRIPTION
Fixes #165, wherein @dgutov rightly suggested switching over fully to `cl-lib`: this modernises the code, at the expense of a package dependency.

All tests are passing.

I haven't put in the legwork to make the non-snapshot travis build work properly, which would involve figuring out how to auto-install `cl-lib` there, but if this PR is generally acceptable, then I'll look into doing that.
