### PR TITLE
js2-pretty-multiline-declarations: Add 'dynamic option

### DIFF
--- a/tests/indent.el
+++ b/tests/indent.el
@@ -112,3 +112,30 @@
   |  are kept
   |        unchanged!`"
   :keep-indent t)
+
+(js2-deftest-indent no-multiline-decl-first-arg-function-dynamic
+  "var foo = function() {
+  |  return 7;
+  |};"
+  :bind ((js2-pretty-multiline-declarations 'dynamic)))
+
+(js2-deftest-indent multiline-decl-first-arg-function-indent-dynamic
+  "var foo = function() {
+  |      return 7;
+  |    },
+  |    bar = 8;"
+  :bind ((js2-pretty-multiline-declarations 'dynamic)))
+
+(js2-deftest-indent multiline-decl-first-arg-function-indent-dynamic-comment
+  "var foo = function() {
+  |      return 7;
+  |    }/* MUAHAHAHA, ah ha! */,
+  |    bar = 8;"
+  :bind ((js2-pretty-multiline-declarations 'dynamic)))
+
+(js2-deftest-indent multiline-decl-first-arg-function-indent-dynamic-scan-error
+  "var foo = function() {
+  |  return 7;
+  |  ,
+  |  bar = 8;"
+  :bind ((js2-pretty-multiline-declarations 'dynamic)))


### PR DESCRIPTION
I liked how `js2-mode` indented multiline `var` statements, for the most part. But when it came to function expressions and object/array literals, I felt that the settings fell short.

With `(setq js2-pretty-multiline-declarations t)`, I got this:

```js
var a = function () {
    // Body.
};
```

But I also got this:

```js
var a = function () {
    // Body.
},
    b = function () {
        // Body.
    };
```

I did not like how the function bodies didn't align nicely.

So when I tried `(setq js2-pretty-multiline-declarations 'all)`, I was happy to find that I got this:

```js
var a = function () {
        // Body.
    },
    b = function () {
        // Body.
    };
```

But then I got this too:

```js
var a = function () {
        // Body.
    };
```

If there isn't another function in the `var` declaration to align against, the indentation seems superfluous, and I would rather not do it.

In the interest of maintaining backwards-compatibility for anyone who likes the `t` or `'all` behaviors, I have added a new property, `'dynamic`.

With `(setq js2-pretty-multiline-declarations 'dynamic)`, I get this:

```js
var a = function () {
    // Body.
};
```

And this:

```js
var a = function () {
        // Body.
    },
    b = function () {
        // Body.
    };
```

Which is exactly what I wanted. This PR provides that functionality.

I filled out and submitted a copyright assignment form two weeks ago, requesting to contribute another plugin of mine to `savannah.gnu.org/projects/emacs/`. I am not sure if I need to fill out a separate form to contribute to this repository, but I am willing to do so if needed.