### PR TITLE
Define "arguments" as a symbol inside functions

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7763,6 +7763,7 @@ Scanner should be initialized."
                                    (js2-parse-expr t))))))
 
 (defun js2-parse-function-body (fn-node)
+  (js2-define-symbol js2-FUNCTION "arguments" fn-node)
   (js2-must-match js2-LC "msg.no.brace.body"
                   (js2-node-pos fn-node)
                   (- js2-ts-cursor (js2-node-pos fn-node)))


### PR DESCRIPTION
While using my [context-coloring](https://github.com/jacksonrayhamilton/context-coloring) plugin, I noticed that `arguments` was being treated as a global variable inside functions.

<p align="center">
  <img src="http://img42.com/ImRka+" alt="Nested functions, the word 'arguments' is white">
</p>

According [ECMA 262, section 10.6](http://www.ecma-international.org/ecma-262/5.1/#sec-10.6):

> When control enters an execution context for function code, an arguments object is created unless (as specified in 10.5) the identifier arguments occurs as an Identifier in the function’s FormalParameterList or occurs as the Identifier of a VariableDeclaration or FunctionDeclaration contained in the function code.

So I dropped `(js2-define-symbol js2-FUNCTION "arguments" fn-node)` inside `js2-parse-function-body`. I'm not sure if anything else is needed to ensure that `arguments` is defined in each `function`'s scope.

It seems to have solved the issue:

<p align="center">
  <img src="http://img42.com/ap2FQ+" alt="Nested functions, the word 'arguments' is the same color as the functions">
</p>