### PR TITLE
Bump the version

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7,7 +7,7 @@
 ;;         Dmitry Gutov <dgutov@yandex.ru>
 ;; URL:  https://github.com/mooz/js2-mode/
 ;;       http://code.google.com/p/js2-mode/
-;; Version: 20141118
+;; Version: 20150201
 ;; Keywords: languages, javascript
 ;; Package-Requires: ((emacs "24.1") (cl-lib "0.5"))
 


### PR DESCRIPTION
Hi, it's me again.

I'm preparing to release my [`context-coloring`](https://github.com/jacksonrayhamilton/context-coloring) package on ELPA, and your package is one of my dependencies.

However, it would be nice if the latest version of this package was available on ELPA. It has two updates which will improve the experience for users of my plugin: Namely, the fix for `catch` block scopes, and the fix for `arguments` scope. Thus I have marked my `Package-Requires` section as `(... (js2-mode "20150126"))`, but unless MELPA is available, my package can't be installed.

Thanks. Hopefully the package feels "stable" enough right now for another release.