### PR TITLE
Add js2-declare-variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,5 @@ js2-imenu-extras.elc: js2-mode.elc
 
 test:
 	${EMACS} $(BATCHFLAGS) -l js2-mode.el -l tests/parser.el\
-	  -l tests/indent.el -l tests/externs.el -f ert-run-tests-batch-and-exit
+	  -l tests/indent.el -l tests/externs.el -l tests/utilities.el\
+	  -f ert-run-tests-batch-and-exit

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -6169,8 +6169,6 @@ its relevant fields and puts it into `js2-ti-tokens'."
                              (setf (js2-token-beg token) (- js2-ts-cursor 2))
                              (js2-skip-line)
                              (setf (js2-token-comment-type token) 'line)
-                             ;; include newline so highlighting goes to end of window
-                             (cl-incf (js2-token-end token))
                              (throw 'return js2-COMMENT))
                            ;; is it a /* comment?
                            (when (js2-match-char ?*)

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12455,7 +12455,7 @@ will be inserted after them."
           (forward-char)
           (next-logical-line)
           (back-to-indentation))
-         ;; Just go to the beginning of the scripts.
+         ;; Just go to the beginning of scripts.
          ((= scope-type js2-SCRIPT)
           (goto-char (js2-node-abs-pos scope))))
         ;; Ensure a "use strict" statement (if there is one) always comes before
@@ -12464,7 +12464,6 @@ will be inserted after them."
                             (js2-node-string scope))
           (goto-char (+ (js2-node-abs-pos scope)
                         (match-end 0)))
-          ;; Only add a newline if necessary.
           (js2-conservatively-goto-next-line)
           (back-to-indentation))
         ;; Sidestep comments and rearrange code in preparation for `var'

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12395,17 +12395,15 @@ will be inserted after them."
       (setq declaration (concat identifier " = " initialiser)))
     ;; Find the nearest non-catch-block-scope.  This loop has the intentional
     ;; side-effects of assigning the values of `scope' and `scope-type'.
-    (let ((continue t))
-      (setq scope node-at-point)
-      (while continue
-        (setq scope (js2-node-get-enclosing-scope scope))
-        (if (not scope)
-            ;; Stopping point.
-            (setq continue nil)
-          (setq scope-type (js2-scope-type scope))
-          ;; Ignore non-function and non-global scopes.
-          (setq continue (not (or (= scope-type js2-FUNCTION)
-                                  (= scope-type js2-SCRIPT)))))))
+    (setq scope node-at-point)
+    (while (and
+            ;; Only continue if there is still a scope to analyze.
+            (setq scope (js2-node-get-enclosing-scope scope))
+            (progn
+              (setq scope-type (js2-scope-type scope))
+              ;; Ignore non-function and non-global scopes.
+              (not (or (= scope-type js2-FUNCTION)
+                       (= scope-type js2-SCRIPT))))))
     ;; No scope implies the global scope.
     (when (not scope)
       (setq scope js2-mode-ast)
@@ -12453,7 +12451,8 @@ will be inserted after them."
           (goto-char (js2-node-abs-pos scope))))
         ;; Ensure a "use strict" statement (if there is one) always comes before
         ;; the declaration.
-        (when (string-match "\\(?:\"\\|'\\)use strict\\(?:\"\\|'\\);?" (js2-node-string scope))
+        (when (string-match "\\(?:\"\\|'\\)use strict\\(?:\"\\|'\\);?"
+                            (js2-node-string scope))
           (goto-char (+ (js2-node-abs-pos scope)
                         (match-end 0)))
           (if (looking-at "\n")

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12393,8 +12393,8 @@ will be inserted after them."
     (when (and initialiser
                (not (string-match "^[[:space:]\\|\n]*$" initialiser)))
       (setq declaration (concat identifier " = " initialiser)))
-    ;; Find the nearest non-catch-block-scope.  This loop has the intentional
-    ;; side-effects of assigning the values of `scope' and `scope-type'.
+    ;; Find the nearest scope.  This loop has the intentional side-effects of
+    ;; assigning the values of `scope' and `scope-type'.
     (setq scope node-at-point)
     (while (and
             ;; Only continue if there is still a scope to analyze.
@@ -12431,7 +12431,7 @@ will be inserted after them."
                (insert declaration))
              (setq found-variable-declaration t))
            (setq visited-first-node t)
-           ;; Keep searching if the `var' was not found.
+           ;; Keep searching if a `var' was not found.
            (not found-variable-declaration)))))
     ;; Create a `var' statement if one was not found.
     (when (not found-variable-declaration)
@@ -12473,9 +12473,11 @@ will be inserted after them."
                   (forward-comment 1)
                   (next-logical-line)
                   t)
-                 ((not (or (looking-at "\n")
-                           ;; There won't be a newline at the end of the buffer.
-                           (= (point) (buffer-end 1))))
+                 ((not (or
+                        ;; There's no need to make space if space is available.
+                        (looking-at "\n")
+                        ;; There won't be a newline at the end of the buffer.
+                        (= (point) (buffer-end 1))))
                   ;; Move any other code out of the way.
                   (newline-and-indent)
                   (previous-logical-line)

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12392,7 +12392,8 @@ will be inserted after them."
         scope
         scope-type
         visited-first-node
-        found-variable-declaration)
+        found-variable-declaration
+        function-braces-need-newlines)
     ;; Build a declaration from the information supplied by the caller.
     (if (and initialiser
              (not (string-match "^[[:space:]\\|\n]*$" initialiser)))
@@ -12450,9 +12451,22 @@ will be inserted after them."
          ((= scope-type js2-FUNCTION)
           (goto-char (js2-node-abs-pos scope))
           (forward-sexp)
-          (forward-sexp)
+          (let ((line-number-before (line-number-at-pos)))
+            (forward-sexp)
+            (when (= line-number-before (line-number-at-pos))
+              (setq function-braces-need-newlines t)))
           (backward-sexp)
           (forward-char)
+          (when function-braces-need-newlines
+            (newline)
+            (backward-char)
+            (backward-char)
+            (forward-sexp)
+            (backward-char)
+            (newline-and-indent)
+            (forward-char)
+            (backward-sexp)
+            (forward-char))
           (next-logical-line)
           (back-to-indentation))
          ;; Just go to the beginning of scripts.

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -6169,6 +6169,11 @@ its relevant fields and puts it into `js2-ti-tokens'."
                              (setf (js2-token-beg token) (- js2-ts-cursor 2))
                              (js2-skip-line)
                              (setf (js2-token-comment-type token) 'line)
+                             ;; include newline so highlighting goes to end of
+                             ;; window, if there actually is a newline; if we
+                             ;; hit eof, then implicitly there isn't
+                             (unless js2-ts-hit-eof
+                               (cl-incf (js2-token-end token)))
                              (throw 'return js2-COMMENT))
                            ;; is it a /* comment?
                            (when (js2-match-char ?*)

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12495,7 +12495,7 @@ will be inserted after them."
               (goto-char (match-end 1)))
              ;; Skip the comments themselves.
              ((looking-at "//")
-              (forward-comment 1)
+              (end-of-line 1)
               (js2-conservatively-goto-next-line))
              ((looking-at "/\\*")
               (forward-comment 1)

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -800,3 +800,8 @@ the test."
   (js2-mode)
   (let ((node (js2-node-at-point (point-min))))
     (should (= (js2-node-len node) 2))))
+
+(js2-deftest comment-node-length-newline "//\n"
+  (js2-mode)
+  (let ((node (js2-node-at-point (point-min))))
+    (should (= (js2-node-len node) 3))))

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -793,3 +793,10 @@ the test."
 (js2-deftest function-without-parens-error "function b {}"
   ;; Should finish the parse.
   (js2-mode))
+
+;;; Comments
+
+(js2-deftest comment-node-length "//"
+  (js2-mode)
+  (let ((node (js2-node-at-point (point-min))))
+    (should (= (js2-node-len node) 2))))

--- a/tests/utilities.el
+++ b/tests/utilities.el
@@ -1,0 +1,223 @@
+;;; tests/utilities.el --- Some tests for js2-mode.
+
+;; Copyright (C) 2009, 2011-2015  Free Software Foundation, Inc.
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'ert)
+(require 'js2-mode)
+(require 'cl-lib)
+
+(defun js2-test-declare-variable (before after point args)
+  (let ((before (replace-regexp-in-string "^ *|" "" before))
+        (after (replace-regexp-in-string "^ *|" "" after)))
+    (with-temp-buffer
+      (insert before)
+      (js2-mode)
+      (goto-char point)
+      (apply 'js2-declare-variable args)
+      (should (string= after (buffer-substring-no-properties
+                              (point-min) (point-max)))))))
+
+(cl-defmacro js2-deftest-declare-variable (name &key before
+                                                &key after
+                                                &key point
+                                                &key args
+                                                &key padding)
+  `(ert-deftest ,(intern (format "js2-declare-variable-%s" name)) ()
+     (let ((js2-basic-offset 4)
+           (indent-tabs-mode nil)
+           (js2-pretty-multiline-declarations t)
+           (inhibit-point-motion-hooks t)
+           (js2-declare-variable-padding ,padding))
+       (js2-test-declare-variable ,before ,after ,point ,args))))
+
+(js2-deftest-declare-variable empty
+  :before ""
+  :after  "var a;"
+  :point 1
+  :args '("a"))
+
+(js2-deftest-declare-variable intialiser
+  :before ""
+  :after  "var a = 1;"
+  :point 1
+  :args '("a" "1"))
+
+(js2-deftest-declare-variable append
+  :before "var a;"
+  :after  "var a,
+          |    b;"
+  :point 1
+  :args '("b"))
+
+(js2-deftest-declare-variable padding
+  :before ""
+  :after  "
+           |var a;
+           |"
+  :point 1
+  :args '("a")
+  :padding t)
+
+(js2-deftest-declare-variable nudge
+  :before "void 0;"
+  :after  "var a;
+          |void 0;"
+  :point 1
+  :args '("a"))
+
+(js2-deftest-declare-variable empty-function
+  :before "function f() {
+          |
+          |}"
+  :after  "function f() {
+          |    var a;
+          |}"
+  :point 16 ; Inside the function block
+  :args '("a"))
+
+(js2-deftest-declare-variable append-function
+  :before "function f() {
+          |    var a;
+          |}"
+  :after  "function f() {
+          |    var a,
+          |        b;
+          |}"
+  :point 16
+  :args '("b"))
+
+(js2-deftest-declare-variable function-padding
+  :before "function f() {
+          |
+          |}"
+  :after  "function f() {
+          |
+          |    var a;
+          |
+          |}"
+  :point 16
+  :args '("a")
+  :padding t)
+
+(js2-deftest-declare-variable function-nudge
+  :before "function f() {
+          |    void 0;
+          |}"
+  :after  "function f() {
+          |    var a;
+          |    void 0;
+          |}"
+  :point 16
+  :args '("a"))
+
+(js2-deftest-declare-variable empty-catch
+  :before "try {
+          |
+          |} catch (e) {
+          |
+          |}"
+  :after  "var a;
+          |try {
+          |
+          |} catch (e) {
+          |
+          |}"
+  :point 22 ; Inside the catch block
+  :args '("a"))
+
+(js2-deftest-declare-variable use-strict-double
+  :before "\"use strict\";"
+  :after  "\"use strict\";
+          |var a;"
+  :point 1
+  :args '("a"))
+
+(js2-deftest-declare-variable use-strict-single
+  :before "'use strict';"
+  :after  "'use strict';
+          |var a;"
+  :point 1
+  :args '("a"))
+
+(js2-deftest-declare-variable use-strict-asi
+  :before "'use strict'"
+  :after  "'use strict'
+          |var a;"
+  :point 1
+  :args '("a"))
+
+(js2-deftest-declare-variable use-strict-padding
+  :before "'use strict';"
+  :after  "'use strict';
+          |
+          |var a;
+          |"
+  :point 1
+  :args '("a")
+  :padding t)
+
+(js2-deftest-declare-variable comment-singleline
+  :before "// comment
+          |" ; TODO: Remove newline
+  :after  "// comment
+          |var a;"
+  :point 1
+  :args '("a"))
+
+(js2-deftest-declare-variable comment-multiline
+  :before "/* comment */
+          |" ; TODO: Remove newline
+  :after  "/* comment */
+          |var a;"
+  :point 1
+  :args '("a"))
+
+(js2-deftest-declare-variable comment-padding
+  :before "// comment
+          " ; TODO: Remove newline
+  :after  "// comment
+          |
+          |var a;
+          |"
+  :point 1
+  :args '("a")
+  :padding 1)
+
+(js2-deftest-declare-variable use-strict-then-comment
+  :before "'use strict';
+          |// comment
+          |" ; TODO: Remove newline
+  :after  "'use strict';
+          |// comment
+          |var a;"
+  :point 1
+  :args '("a"))
+
+(js2-deftest-declare-variable use-strict-then-space-then-comment
+  :before "'use strict';
+          |
+          |// comment
+          |" ; TODO: Remove newline
+  :after  "'use strict';
+          |
+          |// comment
+          |var a;"
+  :point 1
+  :args '("a"))

--- a/tests/utilities.el
+++ b/tests/utilities.el
@@ -222,7 +222,7 @@
   :point 1
   :args '("a"))
 
-(js2-deftest-declare-variable scope
+(js2-deftest-declare-variable block-scope
   :before "if (true) {
           |
           |}"
@@ -233,7 +233,7 @@
   :point 13 ; Inside the if block
   :args '("a"))
 
-(js2-deftest-declare-variable scope
+(js2-deftest-declare-variable nested-block-scope
   :before "if (true) {
           |    if (true) {
           |

--- a/tests/utilities.el
+++ b/tests/utilities.el
@@ -127,6 +127,23 @@
   :point 16
   :args '("a"))
 
+(js2-deftest-declare-variable empty-function-oneliner
+  :before "function f() { }"
+  :after  "function f() {
+          |    var a;
+          |}"
+  :point 16 ; Inside the function block
+  :args '("a"))
+
+(js2-deftest-declare-variable function-oneliner-nudge
+  :before "function f() { void 0; }"
+  :after  "function f() {
+          |    var a;
+          |    void 0;
+          |}"
+  :point 16
+  :args '("a"))
+
 (js2-deftest-declare-variable empty-catch
   :before "try {
           |

--- a/tests/utilities.el
+++ b/tests/utilities.el
@@ -221,3 +221,29 @@
           |var a;"
   :point 1
   :args '("a"))
+
+(js2-deftest-declare-variable scope
+  :before "if (true) {
+          |
+          |}"
+  :after  "var a;
+          |if (true) {
+          |
+          |}"
+  :point 13 ; Inside the if block
+  :args '("a"))
+
+(js2-deftest-declare-variable scope
+  :before "if (true) {
+          |    if (true) {
+          |
+          |    }
+          |}"
+  :after  "var a;
+          |if (true) {
+          |    if (true) {
+          |
+          |    }
+          |}"
+  :point 29 ; Inside the nested if block
+  :args '("a"))

--- a/tests/utilities.el
+++ b/tests/utilities.el
@@ -197,6 +197,13 @@
   :point 1
   :args '("a"))
 
+(js2-deftest-declare-variable comment-singleline-newline
+  :before "// comment\n"
+  :after  "// comment
+          |var a;"
+  :point 1
+  :args '("a"))
+
 (js2-deftest-declare-variable comment-multiline
   :before "/* comment */"
   :after  "/* comment */
@@ -206,6 +213,16 @@
 
 (js2-deftest-declare-variable comment-padding
   :before "// comment"
+  :after  "// comment
+          |
+          |var a;
+          |"
+  :point 1
+  :args '("a")
+  :padding 1)
+
+(js2-deftest-declare-variable comment-padding-newline
+  :before "// comment\n"
   :after  "// comment
           |
           |var a;

--- a/tests/utilities.el
+++ b/tests/utilities.el
@@ -174,24 +174,21 @@
   :padding t)
 
 (js2-deftest-declare-variable comment-singleline
-  :before "// comment
-          |" ; TODO: Remove newline
+  :before "// comment"
   :after  "// comment
           |var a;"
   :point 1
   :args '("a"))
 
 (js2-deftest-declare-variable comment-multiline
-  :before "/* comment */
-          |" ; TODO: Remove newline
+  :before "/* comment */"
   :after  "/* comment */
           |var a;"
   :point 1
   :args '("a"))
 
 (js2-deftest-declare-variable comment-padding
-  :before "// comment
-          " ; TODO: Remove newline
+  :before "// comment"
   :after  "// comment
           |
           |var a;
@@ -202,8 +199,7 @@
 
 (js2-deftest-declare-variable use-strict-then-comment
   :before "'use strict';
-          |// comment
-          |" ; TODO: Remove newline
+          |// comment"
   :after  "'use strict';
           |// comment
           |var a;"
@@ -213,8 +209,7 @@
 (js2-deftest-declare-variable use-strict-then-space-then-comment
   :before "'use strict';
           |
-          |// comment
-          |" ; TODO: Remove newline
+          |// comment"
   :after  "'use strict';
           |
           |// comment


### PR DESCRIPTION
I have a little present for you: A new utility function, `js2-declare-variable`!

`js2-declare-variable` makes it easy to extend `var` statements. Bound to C-c C-v, just enter the name of a variable (and optionally its initial value) and `js2-declare-variable` will append the declaration to the first `var` statement in the scope enclosing point.

If there isn't already a `var` statement in the enclosing scope, one will be created.

If there is a `"use strict"` statement or comments at the top of the enclosing scope, the `var` statement will be inserted after them.

In implementing this, I discovered a bug in `js2-node-get-enclosing-scope` where a node without a parent would trigger an error, because `js2-node-parent` could not operate on `nil`. The new fuction requires `js2-node-get-enclosing-scope` to behave correctly, so I fixed it.

I also noticed #218 when writing the `js2-declare-variable-comment-*` tests, so I simply added an extra newline in those tests to prevent that particular error. I would rather they not be there, so I marked them with TODOs until that bug is fixed. (**Update:** e054673 and efdc5f6 fixed that.)

I have signed the copyright forms for Emacs and they have been approved; I guess that means I can legally contribute to this repository as well?

I hope you like this feature and thanks for your review.