### PR TITLE
Fix js2-node-get-enclosing-scope

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -2307,10 +2307,9 @@ If any given node in NODES is nil, doesn't record that link."
 (defun js2-node-get-enclosing-scope (node)
   "Return the innermost `js2-scope' node surrounding NODE.
 Returns nil if there is no enclosing scope node."
-  (let ((parent (js2-node-parent node)))
-    (while (not (js2-scope-p parent))
-      (setq parent (js2-node-parent parent)))
-    parent))
+  (while (and (setq node (js2-node-parent node))
+              (not (js2-scope-p node))))
+  node)
 
 (defun js2-get-defining-scope (scope name &optional point)
   "Search up scope chain from SCOPE looking for NAME, a string or symbol.


### PR DESCRIPTION
Previously this function discriminated against nodes that did not have parents. For such nodes, `nil` should have been returned, but instead an error was emitted, because a parentless node would produce the initial parent `nil` which would cause `js2-node-parent` to blow up. This fixes that.

Originally this was going to be a throw-in for [\#219](https://github.com/mooz/js2-mode/pull/219), but considering we might not merge that in, I'd like to get this fix in so I can move forward on a `js2-refactor` version of [\#219](https://github.com/mooz/js2-mode/pull/219).