### PR TITLE
Don't unset `js2-recorded-identifiers'

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7079,8 +7079,7 @@ it is considered declared."
                     (member name js2-additional-externs)
                     (js2-get-defining-scope scope name pos))
           (js2-report-warning "msg.undeclared.variable" name pos (- end pos)
-                              'js2-external-variable))))
-    (setq js2-recorded-identifiers nil)))
+                              'js2-external-variable))))))
 
 (defun js2-set-default-externs ()
   "Set the value of `js2-default-externs' based on the various


### PR DESCRIPTION
Forgive me if I'm missing something, but I don't see why this variable is being unset.

It would be useful if it was still set, especially if a minor mode wanted to analyze the identifiers from `js2-mode`'s initial parse. Before this change, a minor mode would have to set up a `js2-post-parse-callback` and reparse for no reason in order to get access to the `js2-recorded-identifiers`.