### PR TITLE
Implement bind operators

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -738,6 +738,7 @@ parser as a frontend to an interpreter or byte compiler.")
 (js2-deflocal js2-compiler-use-dynamic-scope nil)
 (js2-deflocal js2-compiler-reserved-keywords-as-identifier nil)
 (js2-deflocal js2-compiler-xml-available t)
+(js2-deflocal js2-compiler-e4x-accessor-available nil)
 (js2-deflocal js2-compiler-optimization-level 0)
 (js2-deflocal js2-compiler-generating-source t)
 (js2-deflocal js2-compiler-strict-mode nil)
@@ -10065,7 +10066,7 @@ Last token parsed must be `js2-RB'."
     (when (= tt js2-DOTDOT)
       (js2-must-have-xml)
       (setq member-type-flags js2-descendants-flag))
-    (if (not js2-compiler-xml-available)
+    (if (not js2-compiler-e4x-accessor-available)
         (progn
           (js2-must-match-prop-name "msg.no.name.after.dot")
           (setq name (js2-create-name-node t js2-GETPROP)
@@ -10298,7 +10299,7 @@ array-literals, array comprehensions and regular expressions."
 (defun js2-parse-name (_tt)
   (let ((name (js2-current-token-string))
         node)
-    (setq node (if js2-compiler-xml-available
+    (setq node (if js2-compiler-e4x-accessor-available
                    (js2-parse-property-name nil name 0)
                  (js2-create-name-node 'check-activation nil name)))
     (if js2-highlight-external-variables

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -338,6 +338,23 @@ the test."
 (js2-deftest-parse arrow-function-recovers-from-error
   "[(,foo) => 1];" :syntax-error "," :errors-count 6)
 
+;;; Bind operators
+
+(js2-deftest-parse unary-bind-operator
+  "::a.b;")
+
+(js2-deftest-parse unary-bind-operator-with-call
+  "::a.b();")
+
+(js2-deftest-parse binary-bind-operator
+  "a :: b;")
+
+(js2-deftest-parse binary-bind-operator-with-call
+  "a :: b();")
+
+(js2-deftest-parse bind-operator-chain
+  "::a.b :: c :: d;")
+
 ;;; Automatic semicolon insertion
 
 (js2-deftest-parse no-auto-semi-insertion-after-if


### PR DESCRIPTION
Bind operators as specified by https://github.com/zenparsing/es-function-bind.

This turns off E4X accessors separately because there is a conflict; simple XML literals as used by JSX is preserved.