### PR TITLE
Allow semicolons in a class body

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10649,6 +10649,10 @@ expression)."
         (if after-comma
             (js2-parse-warn-trailing-comma "msg.extra.trailing.comma"
                                            pos elems after-comma)))
+       ;; Skip semicolons in a class body
+       ((and class-p
+             (= tt js2-SEMI))
+        nil)
        (t
         (js2-report-error "msg.bad.prop")
         (unless js2-recover-from-parse-errors

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -766,6 +766,9 @@ the test."
 (js2-deftest-parse parse-class-keywordlike-method
   "class C {\n  delete() {}\n  if() {}\n}")
 
+(js2-deftest-parse parse-harmony-class-allow-semicolon-element
+  "class Foo {;}" :reference "class Foo {\n}")
+
 ;;; Scopes
 
 (js2-deftest ast-symbol-table-includes-fn-node "function foo() {}"


### PR DESCRIPTION
This is published ES6.  Do you want more tests?  I admit the test is a little too simple.