### PR TITLE
Allow 0o octals in strict mode

### DIFF
--- a/tests/parser.el
+++ b/tests/parser.el
@@ -320,6 +320,9 @@ the test."
   "'use strict';\nvar number = 0644;"
   :syntax-error "0644" :errors-count 1)
 
+(js2-deftest-parse function-strict-octal-allow-0o
+  "'use strict';\n0o644;" :reference "'use strict';\n420;")
+
 (js2-deftest-parse function-strict-duplicate-keys
   "'use strict';\nvar object = {a: 1, a: 2, 'a': 3, ['a']: 4, 1: 5, '1': 6, [1 + 1]: 7};"
   :syntax-error "a" :errors-count 4) ; "a" has 3 dupes, "1" has 1 dupe.


### PR DESCRIPTION
0o octals are allowed in ES6 strict mode, while octals like 0123 are
called LegacyOctalIntegerLiteral and remain disallowed.

New style octals are used in nodejs code.