### PR TITLE
Fix semicolons and scoping in exported decls

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -8842,20 +8842,30 @@ invalid export statements."
               (setq from-clause (js2-parse-from-clause)))
           (js2-unget-token))))
      ((js2-match-token js2-DEFAULT)
-      (setq default (js2-parse-expr)))
+      (setq default (cond ((js2-match-token js2-CLASS)
+                           (js2-parse-class-stmt))
+                          ((js2-match-token js2-FUNCTION)
+                           (js2-parse-function-stmt))
+                          (t (js2-parse-expr)))))
      ((or (js2-match-token js2-VAR) (js2-match-token js2-CONST) (js2-match-token js2-LET))
       (setq declaration (js2-parse-variables (js2-current-token-type) (js2-current-token-beg))))
+     ((js2-match-token js2-CLASS)
+      (setq declaration (js2-parse-class-stmt)))
+     ((js2-match-token js2-FUNCTION)
+      (setq declaration (js2-parse-function-stmt)))
      (t
       (setq declaration (js2-parse-expr))))
     (when from-clause
       (push from-clause children))
     (when declaration
       (push declaration children)
-      (when (not (js2-function-node-p declaration))
+      (when (not (or (js2-function-node-p declaration)
+                     (js2-class-node-p declaration)))
         (js2-auto-insert-semicolon declaration)))
     (when default
       (push default children)
-      (when (not (js2-function-node-p default))
+      (when (not (or (js2-function-node-p default)
+                     (js2-class-node-p default)))
         (js2-auto-insert-semicolon default)))
     (let ((node (make-js2-export-node
                   :pos beg

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -748,7 +748,7 @@ the test."
     (should export-node)
     (should (js2-var-decl-node-p (js2-export-node-declaration export-node)))))
 
-(js2-deftest export-class-declaration "export class Foo {};"
+(js2-deftest export-class-declaration "export class Foo {}"
   (js2-init-scanner)
   (js2-push-scope (make-js2-scope :pos 0))
   (should (js2-match-token js2-EXPORT))
@@ -756,7 +756,7 @@ the test."
     (should export-node)
     (should (js2-class-node-p (js2-export-node-declaration export-node)))))
 
-(js2-deftest export-function-declaration "export default function doStuff() {};"
+(js2-deftest export-function-declaration "export default function doStuff() {}"
   (js2-init-scanner)
   (js2-push-scope (make-js2-scope :pos 0))
   (should (js2-match-token js2-EXPORT))
@@ -764,7 +764,7 @@ the test."
     (should export-node)
     (should (js2-export-node-default export-node))))
 
-(js2-deftest export-generator-declaration "export default function* one() {};"
+(js2-deftest export-generator-declaration "export default function* one() {}"
   (js2-init-scanner)
   (js2-push-scope (make-js2-scope :pos 0))
   (should (js2-match-token js2-EXPORT))
@@ -795,8 +795,8 @@ the test."
 (js2-deftest-parse parse-re-export-named-list "export {foo, bar as bang} from 'other/lib';")
 (js2-deftest-parse parse-export-const-declaration "export const PI = Math.PI;")
 (js2-deftest-parse parse-export-let-declaration "export let foo = [1];")
-(js2-deftest-parse parse-export-function-declaration "export default function doStuff() {};")
-(js2-deftest-parse parse-export-generator-declaration "export default function* one() {};")
+(js2-deftest-parse parse-export-function-declaration "export default function doStuff() {\n}\n;")
+(js2-deftest-parse parse-export-generator-declaration "export default function* one() {\n}\n;")
 (js2-deftest-parse parse-export-assignment-expression "export default a = b;")
 
 ;;; Strings


### PR DESCRIPTION
In the following code, no semicolons should be considered missing,
and all of A,B,C,D should be considered declared.

```
export function A() {}
export class B {}
export default function C() {}
export default class D {}

var x = [A, B, C, D];
```

This should fix #215.

The approach here of parsing functions and classes as statements seems to work.

See also;
* [`export` language grammar](http://www.ecma-international.org/ecma-262/6.0/#sec-exports)
* [Discussion of semicolons over at eslint](https://github.com/eslint/eslint/issues/2194)