### PR TITLE
Recognize for-of and for-in loops with const

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -8924,7 +8924,7 @@ Last matched token must be js2-FOR."
              ((= tt js2-SEMI)
               (js2-unget-token)
               (setq init (make-js2-empty-expr-node)))
-             ((or (= tt js2-VAR) (= tt js2-LET))
+             ((or (= tt js2-VAR) (= tt js2-LET) (= tt js2-CONST))
               (setq init (js2-parse-variables tt (js2-current-token-beg))))
              (t
               (js2-unget-token)


### PR DESCRIPTION
Declarations in for-of and for-in loops may also be "const".  See
http://www.ecma-international.org/ecma-262/6.0/#sec-runtime-semantics-bindinginstantiation