### PR TITLE
Fix void async await

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -3479,6 +3479,7 @@ The type field inherited from `js2-node' holds the operator."
                (cons js2-INSTANCEOF "instanceof")
                (cons js2-DELPROP "delete")
                (cons js2-AWAIT "await")
+               (cons js2-VOID "void")
                (cons js2-COMMA ",")
                (cons js2-COLON ":")
                (cons js2-OR "||")
@@ -3580,7 +3581,8 @@ property is added if the operator follows the operand."
       (insert op))
     (if (or (= tt js2-TYPEOF)
             (= tt js2-DELPROP)
-            (= tt js2-AWAIT))
+            (= tt js2-AWAIT)
+            (= tt js2-VOID))
         (insert " "))
     (js2-print-ast (js2-unary-node-operand n) 0)
     (when postfix

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7766,7 +7766,16 @@ string is NAME.  Returns nil and keeps current token otherwise."
 
 (defun js2-match-await (tt)
   (when (and (= tt js2-NAME)
-             (js2-contextual-kwd-p (js2-current-token) "await"))
+             (js2-contextual-kwd-p (js2-current-token) "await")
+             ;; Per the proposal, AwaitExpression consists of "await"
+             ;; followed by a UnaryExpression.  So look ahead for one.
+             (let ((ts-state (make-js2-ts-state))
+                   js2-recorded-identifiers
+                   js2-parsed-errors)
+               (js2-get-token)
+               (prog1
+                   (/= (js2-node-type (js2-parse-unary-expr)) js2-ERROR)
+                 (js2-ts-seek ts-state))))
     (js2-record-face 'font-lock-keyword-face)
     (let ((beg (js2-current-token-beg))
           (end (js2-current-token-end)))

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7749,20 +7749,9 @@ string is NAME.  Returns nil and keeps current token otherwise."
     (js2-get-token)
     t))
 
-;; Matching "async" is performed in two parts, because in the functions' one use
-;; case, it isn't known whether an arrow function is actually being parsed (and
-;; thus whether `js2-get-token' should be called) until later.  If
-;; `js2-get-token' were called eccentrically, `js2-current-token' would be
-;; off-by-one, causing `js2-parse-unary-expr' to potentially fail when "async"
-;; is used in a non-keyword context.
-
-(defun js2-match-async-arrow-function-1 ()
+(defun js2-match-async-arrow-function ()
   (and (js2-contextual-kwd-p (js2-current-token) "async")
        (/= (js2-peek-token) js2-FUNCTION)))
-
-(defun js2-match-async-arrow-function-2 ()
-  (js2-record-face 'font-lock-keyword-face)
-  (js2-get-token))
 
 (defun js2-parse-await-maybe (tt)
   "Parse \"await\" as an AwaitExpression, if it is one."
@@ -9705,7 +9694,7 @@ If NODE is non-nil, it is the AST node associated with the symbol."
       ;; `js2-parse-function-stmt' nor `js2-parse-function-expr' that
       ;; interpret `async` token, we trash `async` and just remember
       ;; we met `async` keyword to `async-p'.
-      (when (js2-match-async-arrow-function-1)
+      (when (js2-match-async-arrow-function)
         (setq async-p t))
       ;; Save the tokenizer state in case we find an arrow function
       ;; and have to rewind.
@@ -9741,7 +9730,8 @@ If NODE is non-nil, it is the AST node associated with the symbol."
              (>= js2-language-version 200))
         (js2-ts-seek ts-state)
         (when async-p
-          (js2-match-async-arrow-function-2))
+          (js2-record-face 'font-lock-keyword-face)
+          (js2-get-token))
         (setq js2-recorded-identifiers recorded-identifiers
               js2-parsed-errors parsed-errors)
         (setq pn (js2-parse-function 'FUNCTION_ARROW (js2-current-token-beg) nil async-p)))

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7753,6 +7753,9 @@ string is NAME.  Returns nil and keeps current token otherwise."
   (and (js2-contextual-kwd-p (js2-current-token) "async")
        (/= (js2-peek-token) js2-FUNCTION)))
 
+(defsubst js2-inside-function ()
+  (cl-plusp js2-nesting-of-function))
+
 (defun js2-parse-await-maybe (tt)
   "Parse \"await\" as an AwaitExpression, if it is one."
   (let (pn post-parse-ts-state)
@@ -7836,9 +7839,6 @@ Returns t on match, nil if no match."
       (js2-report-error msg-id)
       (js2-unget-token))
     nil))
-
-(defsubst js2-inside-function ()
-  (cl-plusp js2-nesting-of-function))
 
 (defun js2-set-requires-activation ()
   (if (js2-function-node-p js2-current-script-or-fn)

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7754,7 +7754,7 @@ string is NAME.  Returns nil and keeps current token otherwise."
 ;; thus whether `js2-get-token' should be called) until later.  If
 ;; `js2-get-token' were called eccentrically, `js2-current-token' would be
 ;; off-by-one, causing `js2-parse-unary-expr' to potentially fail when "async"
-;; is unused in a non-keyword context.
+;; is used in a non-keyword context.
 
 (defun js2-match-async-arrow-function-1 ()
   (and (js2-contextual-kwd-p (js2-current-token) "async")

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -126,6 +126,9 @@ the test."
 (js2-deftest-parse let-expression-statement
   "let (x = 42) x;")
 
+(js2-deftest-parse void
+  "void 0;")
+
 ;;; Callers of `js2-valid-prop-name-token'
 
 (js2-deftest-parse parse-property-access-when-not-keyword

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -161,6 +161,12 @@ the test."
 (js2-deftest-parse parse-for-of
   "for (var a of []) {\n}")
 
+(js2-deftest-parse of-can-be-name
+  "void of;")
+
+(js2-deftest-parse of-can-be-object-name
+  "of.z;")
+
 (js2-deftest-parse of-can-be-var-name
   "var of = 3;")
 

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -487,6 +487,12 @@ the test."
 
 ;;; 'async' and 'await' are contextual keywords
 
+(js2-deftest-parse async-can-be-name
+  "void async;")
+
+(js2-deftest-parse async-can-be-object-name
+  "async.z;")
+
 (js2-deftest-parse async-can-be-var-name
   "var async = 3;")
 

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -499,6 +499,12 @@ the test."
 (js2-deftest-parse async-can-be-function-name
   "function async() {\n}")
 
+(js2-deftest-parse await-can-be-name
+  "void await;")
+
+(js2-deftest-parse await-can-be-object-name
+  "await.z;")
+
 (js2-deftest-parse await-can-be-var-name
   "var await = 3;")
 


### PR DESCRIPTION
Fixes some parsing errors with unary expressions.

A little while ago I observed the issue described in #300, and finally I was spurred to fix it. I discovered `js2-match-async-arrow-function` caused an off-by-one error, so I prevented that.

I also noticed that `await` parsing was too eager, so I added an extra guard there.

I also noticed that `void` was not being printed correctly with `js2-print-tree`, so I fixed that too.