### PR TITLE
Allow space before global declaration

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7264,7 +7264,7 @@ are ignored."
            when (and (eq 'block (js2-comment-node-format node))
                      (save-excursion
                        (goto-char (js2-node-abs-pos node))
-                       (looking-at "/\\*global ")))
+                       (looking-at "/\\* *global ")))
            append (js2-get-jslint-globals-in
                    (match-end 0)
                    (js2-node-abs-end node))))

--- a/tests/externs.el
+++ b/tests/externs.el
@@ -42,6 +42,13 @@
     (should (equal (js2-get-jslint-globals)
                    '("quux" "tee" "$")))))
 
+(ert-deftest js2-finds-jslint-globals-with-space ()
+  (with-temp-buffer
+    (insert "/* global foo, bar:false, baz:true")
+    (js2-mode)
+    (should (equal (js2-get-jslint-globals)
+                   '("foo" "bar" "baz")))))
+
 ;;;TODO
 ;; ensure that any symbols bound with the import syntax are added to the extern list
 ;; ensure that any symbols bound with the export syntax exist in the file scope


### PR DESCRIPTION
I added the allowance for an optional space in a global declaration. 

Eslint syntax for global declarations differs slightly from jslint, and this change makes that syntax considered valid. 