### PR TITLE
Change warning message to not conflict with spec

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -1456,7 +1456,7 @@ the correct number of ARGS must be provided."
          "Compilation produced %s syntax errors.")
 
 (js2-msg "msg.var.redecl"
-         "TypeError: redeclaration of var %s.")
+         "Redeclaration of var %s.")
 
 (js2-msg "msg.const.redecl"
          "TypeError: redeclaration of const %s.")


### PR DESCRIPTION
The ECMAScript spec says
(http://www.ecma-international.org/ecma-262/5.1/#sec-10.5) that
declaring an already declared variable is silently ignored, so claiming
it's a TypeError is not correct. It should still be highlighted as a
warning because it's not something that any program should do and with
let redeclaration actually is a TypeError.