### PR TITLE
Fix Highlighting function name of form {"quoted name" () {...}}

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10871,7 +10871,8 @@ When `js2-is-in-destructuring' is t, forms like {a, b, c} will be permitted."
      ;; method definition: {f() {...}}
      ((and (= (js2-peek-token) js2-LP)
            (>= js2-language-version 200))
-      (when (or (js2-name-node-p key) (js2-string-node-p key)) ; highlight function name properties
+      (when (or (js2-name-node-p key) (js2-string-node-p key))
+        ;; highlight function name properties
         (js2-record-face 'font-lock-function-name-face))
       (js2-parse-method-prop pos key property-type))
      ;; binding element with initializer

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10871,7 +10871,7 @@ When `js2-is-in-destructuring' is t, forms like {a, b, c} will be permitted."
      ;; method definition: {f() {...}}
      ((and (= (js2-peek-token) js2-LP)
            (>= js2-language-version 200))
-      (when (js2-name-node-p key)  ; highlight function name properties
+      (when (or (js2-name-node-p key) (js2-string-node-p key)) ; highlight function name properties
         (js2-record-face 'font-lock-function-name-face))
       (js2-parse-method-prop pos key property-type))
      ;; binding element with initializer


### PR DESCRIPTION
This patch will make "quoted name" use font-lock-function-name-face just
like {"quoted name": function () {...}} does.

I tried to write a test for this but could find no existing tests for checking
face settings.