### PR TITLE
js2-jsx-mode docstring fix

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -11620,7 +11620,7 @@ variables (`sgml-basic-offset' et al) locally, like so:
 
   (defun set-jsx-indentation ()
     (setq-local sgml-basic-offset js2-basic-offset))
-  (add-hook 'js2-jsx-mode-hook #'set-jsx-indentation)"
+  (add-hook \\='js2-jsx-mode-hook #\\='set-jsx-indentation)"
   (set (make-local-variable 'indent-line-function) #'js2-jsx-indent-line))
 
 (defun js2-mode-exit ()


### PR DESCRIPTION
Reference: http://lists.gnu.org/archive/html/emacs-devel/2016-07/msg00297.html