### PR TITLE
Special methods should allow keywords as names

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7734,14 +7734,14 @@ is only true until the node is added to its parent; i.e., while parsing."
         ;; Tell cc-engine the bounds of the comment.
         (js2-record-text-property beg (1- end) 'c-in-sws t)))))
 
-(defun js2-peek-token ()
+(defun js2-peek-token (&optional modifier)
   "Return the next token type without consuming it.
 If `js2-ti-lookahead' is positive, return the type of next token
 from `js2-ti-tokens'.  Otherwise, call `js2-get-token'."
   (if (not (zerop js2-ti-lookahead))
       (js2-token-type
        (aref js2-ti-tokens (mod (1+ js2-ti-tokens-cursor) js2-ti-ntokens)))
-    (let ((tt (js2-get-token-internal nil)))
+    (let ((tt (js2-get-token-internal modifier)))
       (js2-unget-token)
       tt)))
 
@@ -10805,7 +10805,7 @@ expression)."
         (when (and (>= js2-language-version 200)
                    (= js2-NAME tt)
                    (member prop '("get" "set" "async"))
-                   (member (js2-peek-token)
+                   (member (js2-peek-token 'KEYWORD_IS_NAME)
                            (list js2-NAME js2-STRING js2-NUMBER js2-LB)))
           (setq previous-token (js2-current-token)
                 tt (js2-get-prop-name-token))))

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -497,6 +497,9 @@ the test."
 (js2-deftest-parse async-method-in-object-literal
   "({async f() {}});")
 
+(js2-deftest-parse async-method-kwname-in-object-literal
+  "({async delete() {}});")
+
 (js2-deftest-parse async-method-in-class-body
   "class C {\n  async foo() {}\n}")
 


### PR DESCRIPTION
Noticed `{ async delete() {} }` parsed incorrectly, and this is a fix.