### PR TITLE
Compute externs on demand

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 ## Next
 
 * Support for ES7 exponentiation operator.
+* The `js2-include-?-externs` are now evaluated on demand.
+  In particular, they can now effectively be used
+  as file- or directory-local variables.
 
 ## 2016-06-23
 

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -7088,13 +7088,13 @@ The list of externs consists of the following:
 See especially `js2-additional-externs' for further details about externs."
   (let ((default-externs
           (append js2-ecma-262-externs
-                  (if js2-include-browser-externs js2-browser-externs)
                   (if (and js2-include-browser-externs
                            (>= js2-language-version 200)) js2-harmony-externs)
                   (if js2-include-rhino-externs js2-rhino-externs)
                   (if js2-include-node-externs js2-node-externs)
                   (if (or js2-include-browser-externs js2-include-node-externs)
-                      js2-typed-array-externs)))
+                      js2-typed-array-externs)
+                  (if js2-include-browser-externs js2-browser-externs)))
         name)
     (dolist (entry js2-recorded-identifiers)
       (cl-destructuring-bind (name-node scope pos end) entry


### PR DESCRIPTION
Instead of only taking into account the `js2-include-?-externs`
variables when initializing the mode, compute what was
`js2-default-externs` before every time we highlight undeclared
identifiers.

Closes #375

### Some notes

In the documentation for `js2-default-externs` it says that **at the moment** the externs are only used to highlight undeclared variables, so I thought a bit about how I can keep my changes very general so that one might use the resulting code for other purposes as well. Since I don't know the code very well, though, I decided YAGNI (for now) and went for the simplest solution (the first one in #375).

I also refactored the documentation a bit correspondingly.

Note that a consequence of these changes is that, other than by overriding `js2-ecma-262-externs` itself, you can now no longer exclude that list from the list of externs.