### PR TITLE
Allow specific warnings to be ignored

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -226,6 +226,13 @@ variable with predicate PRED."
   (make-variable-buffer-local name)
   (put name 'safe-local-variable pred))
 
+(defcustom js2-ignored-warnings nil
+  "A list of warning message types that will not be reported.
+
+Possible values are the keys of `js2-message-table'."
+  :group 'js2-mode
+  :type '(repeat string))
+
 (defcustom js2-highlight-level 2
   "Amount of syntax highlighting to perform.
 0 or a negative value means none.
@@ -8130,10 +8137,22 @@ Scanner should be initialized."
     (setq js2-mode-ast root)  ; Make sure this is available for callbacks.
     ;; Give extensions a chance to muck with things before highlighting starts.
     (let ((js2-additional-externs js2-additional-externs))
+      (js2-filter-parsed-warnings)
       (save-excursion
         (run-hooks 'js2-post-parse-callbacks))
       (js2-highlight-undeclared-vars))
     root))
+
+(defun js2-filter-parsed-warnings ()
+  "Remove `js2-parsed-warnings' elements that match `js2-ignored-warnings'."
+  (when js2-ignored-warnings
+    (setq js2-parsed-warnings
+          (cl-remove-if
+           (lambda (warning)
+             (let ((msg (caar warning)))
+               (member msg js2-ignored-warnings)))
+           js2-parsed-warnings)))
+  js2-parsed-warnings)
 
 (defun js2-parse-function-closure-body (fn-node)
   "Parse a JavaScript 1.8 function closure body."


### PR DESCRIPTION
The need for disabling specific warning messages has come up a few times.

I've seen that there have been changes made to support disabling specific warnings such as dangling commas and no semicolons, but there's not a blanket method for disabling anything you want.

This was discussed shortly in #260, but a conclusion wasn't reached.

This is a much smaller first-class version of the functionality I've built in my own config: https://github.com/jordonbiondo/.emacs.d/blob/master/init.el#L901

Let me know what you think about the possibility of this feature being accepted using this method or any other.