### PR TITLE
Allow trailing comma in param list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # History of user-visible changes
 
+## Next
+
+* Support for trailing commas in function parameter lists.
+
 ## 2017-01-16
 
 * `js2-include-*-externs` are now evaluated on demand.  As a result,

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -8310,7 +8310,9 @@ represented by FN-NODE at POS."
                  (js2-report-error "msg.param.after.rest" nil
                                    (js2-node-pos param) (js2-node-len param)))
                while
-               (js2-match-token js2-COMMA))
+               (and (js2-match-token js2-COMMA)
+                    (or (< js2-language-version 200)
+                        (not (= js2-RP (js2-peek-token))))))
       (when (and (not paren-free-arrow)
                  (js2-must-match js2-RP "msg.no.paren.after.parms"))
         (setf (js2-function-node-rp fn-node) (- (js2-current-token-beg) pos)))

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -300,6 +300,10 @@ the test."
 (js2-deftest-parse function-with-rest-after-default-parameter
   "function foo(a = 1, ...rest) {\n}")
 
+(js2-deftest-parse function-with-trailing-comma-in-param-list
+  "function foo(a, b,) {\n}"
+  :reference "function foo(a, b) {\n}")
+
 ;;; Strict mode errors
 
 (js2-deftest-parse function-bad-strict-parameters


### PR DESCRIPTION
Fixes #403 

I'd like to add a unit test for this, but I don't really know where to start since I'm new to emacs lisp and emacs mode development. There doesn't seem to be a unit test for `js2-parse-function-params` in `tests/parse.el`. Do you think its worth adding one?