### PR TITLE
Map C-M-j to js2-line-break

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -1113,7 +1113,7 @@ information."
 
 (defvar js2-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "M-j") #'js2-line-break)
+    (define-key map [remap indent-new-comment-line] #'js2-line-break)
     (define-key map (kbd "C-c C-e") #'js2-mode-hide-element)
     (define-key map (kbd "C-c C-s") #'js2-mode-show-element)
     (define-key map (kbd "C-c C-a") #'js2-mode-show-all)


### PR DESCRIPTION
In Emacs, `indent-new-comment-line` is bound to both `M-j` and `C-M-j`. `js2-mode` remapped `M-j` to `js2-line-break`, but didn't remap `C-M-j`. This commit fixes that by telling Emacs to remap *all* bindings for `indent-new-comment-line` (currently, just `M-j` and `C-M-j`) to `js2-line-break`.