### PR TITLE
Add option js2-getprop-has-side-effects

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -359,6 +359,13 @@ This is useful for xulrunner apps."
   :type 'boolean
   :group 'js2-mode)
 
+(defcustom js2-getprop-has-side-effects nil
+  "If non-nil, treats the getprop operator as having side effects.
+This is useful for testing libraries with nontrivial getters and for
+compilers that use empty getprops to declare interface properties."
+  :type 'boolean
+  :group 'js2-mode)
+
 (defcustom js2-move-point-on-right-click t
   "Non-nil to move insertion point when you right-click.
 This makes right-click context menu behavior a bit more intuitive,
@@ -5143,8 +5150,6 @@ You should use `js2-print-tree' instead of this function."
                       js2-WITHEXPR
                       js2-YIELD))
       (aset tokens tt t))
-    (if js2-instanceof-has-side-effects
-        (aset tokens js2-INSTANCEOF t))
     tokens))
 
 (defun js2-node-has-side-effects (node)
@@ -5176,6 +5181,9 @@ You should use `js2-print-tree' instead of this function."
         (js2-node-has-side-effects (js2-paren-node-expr node)))
        ((= tt js2-ERROR) ; avoid cascaded error messages
         nil)
+       ((or (and js2-instanceof-has-side-effects (= tt js2-INSTANCEOF))
+            (and js2-getprop-has-side-effects (= tt js2-GETPROP)))
+        t)
        (t
         (aref js2-side-effecting-tokens tt))))))
 

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -1251,3 +1251,40 @@ the test."
 (js2-deftest-classify-variables destructure-object-mixed
   "function foo() { let {a, b, c = 3} = {a: 1, b: 2}; }"
   '("foo@10:U" "a@23:U" "b@26:U" "c@29:U"))
+
+;; Side effects
+
+(js2-deftest no-side-effects-at-top-level
+  "var x; x.foo;"
+  (js2-mode--and-parse)
+  (should (null js2-parsed-warnings)))
+
+(js2-deftest getprop-has-no-side-effects
+  "function f() { this.x; }"
+  (js2-mode--and-parse)
+  (should (equal "msg.no.side.effects"
+                 (car (caar js2-parsed-warnings)))))
+
+(js2-deftest getprop-has-side-effects-option
+  "function f() { this.x; }"
+  (let ((js2-getprop-has-side-effects t))
+    (js2-mode--and-parse)
+    (should (null js2-parsed-warnings))))
+
+(js2-deftest arithmetic-has-no-side-effects
+  "function f() { 1 + 2; }"
+  (js2-mode--and-parse)
+  (should (equal "msg.no.side.effects"
+                 (car (caar js2-parsed-warnings)))))
+
+(js2-deftest instanceof-has-no-side-effects
+  "function f() { this instanceof f; }"
+  (js2-mode--and-parse)
+  (should (equal "msg.no.side.effects"
+                 (car (caar js2-parsed-warnings)))))
+
+(js2-deftest instanceof-has-side-effects-option
+  "function f() { this instanceof f; }"
+  (let ((js2-instanceof-has-side-effects t))
+    (js2-mode--and-parse)
+    (should (null js2-parsed-warnings))))


### PR DESCRIPTION
Includes a slight restructuring of how side-effect calculations are done (for better testability) and adds basic test coverage for no.side.effect warnings.