### PR TITLE
Fix jsdoc highlighting for tags w/ optional braces

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -6943,7 +6943,7 @@ of a simple name.  Called before EXPR has a parent node."
              "throws"
              "type"
              "version"))
-          "\\)\\)\\s-+\\([^ \t]+\\)")
+          "\\)\\)\\s-+\\([^ \t\n]+\\)")
   "Matches jsdoc tags with a single argument.")
 
 (defconst js2-jsdoc-empty-tag-regexp


### PR DESCRIPTION
Some of the tags in js2-jsdoc-arg-tag-regexp (specifically `@this`, `@throws`, and `@type`) are used with braces by Closure Compiler. Previously the close-brace was styled differently from the open-brace.  Adding a branch to the regex for optional braces fixes this.