### PR TITLE
Correctly handle arrow functions in js2-node-parent-stmt

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -5247,8 +5247,7 @@ appearing in a statement context will have a parent that is a
     (if (or (null parent)
             (js2-stmt-node-p parent)
             (and (js2-function-node-p parent)
-                 (not (eq (js2-function-node-form parent)
-                          'FUNCTION_EXPRESSION))))
+                 (eq (js2-function-node-form parent) 'FUNCTION_STATEMENT)))
         parent
       (js2-node-parent-stmt parent))))
 

--- a/tests/consume.el
+++ b/tests/consume.el
@@ -20,6 +20,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'ert-x)
 (require 'js2-mode)
 
 (defun js2-mode--and-parse ()
@@ -73,3 +74,11 @@
                                    t))
      (setq visit-log (nreverse visit-log))
      (should (equal visit-log (list "defaultImport" "a" "b" "c"))))))
+
+(ert-deftest js2-node-parent-stmt/arrow-function ()
+  (ert-with-test-buffer (:name 'js2-node-parent-stmt/arrow-function)
+    (insert "expect(() => ")
+    (save-excursion (insert "func(undefined)).toThrow(/undefined/);"))
+    (js2-mode--and-parse)
+    (let ((parent-stmt (js2-node-parent-stmt (js2-node-at-point))))
+      (should (= (js2-node-abs-pos parent-stmt) 1)))))


### PR DESCRIPTION
Arrow functions are always expressions, so `js2-node-parent-stmt` should
continue recursing to their parent to find the first statement. This could happen
either because it is called with the arrow function node to begin with, or if the
arrow function is brace-less, in which case it doesn't wrap its expression in `js2-expr-stmt-node`