### PR TITLE
Add support for trailing comma in function arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # History of user-visible changes
 
+## Next
+
+* Support for trailing comma in function arguments
+
 ## 2017-07-21
 
 * Support for async arrow function without parentheses.

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10238,7 +10238,9 @@ Returns the list in reverse order.  Consumes the right-paren token."
                    (js2-unget-token)
                    (push (js2-parse-assign-expr) result)))
                while
-               (js2-match-token js2-COMMA))
+               (and (js2-match-token js2-COMMA)
+                    (or (< js2-language-version 200)
+                        (not (= js2-RP (js2-peek-token))))))
       (js2-must-match js2-RP "msg.no.paren.arg")
       result)))
 

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -106,6 +106,10 @@ the test."
 (js2-deftest-parse function-statement
   "function foo() {\n}")
 
+(js2-deftest-parse trailing-comma-in-function-arguments
+   "f(a, b,);"
+   :reference "f(a, b);")
+
 (js2-deftest-parse function-statement-inside-block
   "if (true) {\n  function foo() {\n  }\n}")
 


### PR DESCRIPTION
Fixes #453 

I've tested this using `make test` and also installed patched version locally. For now there are no errors/warnings for this code:
<details>
<summary>Trailing comma in: import, function declaration/call, array, object, export</summary>

```javascript
import {
  a,
  b,
} from 'package';

function f (
  a,
  b,
) {}

f(
  1,
  2,
);

const array = [
  1,
  2,
];

const object = {
  a,
  b,
};

export {
  a,
  f,
};
```
</details>