### PR TITLE
Add @typedef jsdoc highlighting support

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -6909,7 +6909,7 @@ of a simple name.  Called before EXPR has a parent node."
 
 (defconst js2-jsdoc-param-tag-regexp
   (concat "^\\s-*\\*+\\s-*\\(@"
-          "\\(?:param\\|arg\\(?:ument\\)?\\|prop\\(?:erty\\)?\\)"
+          (regexp-opt '("param" "arg" "argument" "prop" "property" "typedef"))
           "\\)"
           "\\s-*\\({[^}]+}\\)?"         ; optional type
           "\\s-*\\[?\\([[:alnum:]_$\.]+\\)?\\]?"  ; name


### PR DESCRIPTION
There's a little bit of a hack: [`@typedef`](usejsdoc.org/tags-typedef.html) is highlighted here the same way as [`@param`](http://usejsdoc.org/tags-param.html), though the grammars are technically different.

The grammar for `@typedef` is `@TAG [OPTIONAL-TYPE] NAME`, whereas `@param` technically has one extra production for the optional description (which js2 doesn't actually match on or highlight)

