### PR TITLE
Fix error when parsing malformed namespace import

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -8761,9 +8761,9 @@ imports or a namespace import that follows it.
         (when ns-import
           (let ((name-node (js2-namespace-import-node-name ns-import)))
             (js2-define-symbol
-             js2-LET (js2-name-node-name name-node) name-node t)))
-        (setf (js2-import-clause-node-namespace-import clause) ns-import)
-        (push ns-import children)))
+             js2-LET (js2-name-node-name name-node) name-node t))
+          (setf (js2-import-clause-node-namespace-import clause) ns-import)
+          (push ns-import children))))
      ((js2-match-token js2-LC)
       (let ((imports (js2-parse-export-bindings t)))
         (setf (js2-import-clause-node-named-imports clause) imports)
@@ -8822,7 +8822,8 @@ The current token must be js2-MUL."
            node)))
       (t
        (js2-unget-token)
-       (js2-report-error "msg.syntax")))))
+       (js2-report-error "msg.syntax")
+       nil))))
 
 
 (defun js2-parse-from-clause ()

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -647,6 +647,11 @@ the test."
       (should (equal "lib" (js2-name-node-name name-node)))
       (should (= 5 (js2-node-pos name-node))))))
 
+(js2-deftest-parse parse-namespace-import-error
+  "import * lib from 'lib';"
+  :syntax-error "import"
+  :errors-count 7)
+
 (js2-deftest parse-from-clause "from 'foo/bar';"
   (js2-init-scanner)
   (let ((from (js2-parse-from-clause)))


### PR DESCRIPTION
Malformed import statements cause the parser to error:

```js
import * lib from 'lib';
```

This patch doesn't add anything in terms of parse-error recovery (the above has 7 parse errors), but it prevents the parser from crashing. I did run a couple of checks and the parser seems to always recover after the quoted source file.