### PR TITLE
Fix js2-node-get-enclosing-scope on a statement function's name

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -2344,6 +2344,15 @@ If any given node in NODES is nil, doesn't record that link."
 (defun js2-node-get-enclosing-scope (node)
   "Return the innermost `js2-scope' node surrounding NODE.
 Returns nil if there is no enclosing scope node."
+  ;; when node is the name of a function statement, the enclosing
+  ;; scope is not that function itself but the surrounding scope.
+  (let ((parent (js2-node-parent node)))
+    (when (and (js2-name-node-p node)
+               (js2-function-node-p parent)
+               (eq 'FUNCTION_STATEMENT (js2-function-node-form parent))
+               (eq node (js2-function-node-name parent)))
+      (setq node parent)))
+  ;; dig up to find the closest scope parent
   (while (and (setq node (js2-node-parent node))
               (not (js2-scope-p node))))
   node)


### PR DESCRIPTION
When called with a statement function's name node,
js2-node-get-enclosing-scope would errorneously return the function itself.
That's not really the scope where this name is defined (it should be the
function's parent scope).

This bug affects js2-refactor's rename variable functionality.  Example:

    (function(){
        function |foo() {
            var |foo = 5;
            console.log(|foo);
        }
        foo();
    })();

(where '|' marks possible cursor position).  Type M-x js2r-rename-var with
the cursor on one of the marked positions, and it'll offer to rename the
following occurrences (marked with underscores):

    (function(){
        function _foo_() {
            var _foo_ = 5;
            console.log(_foo_);
        }
        foo();
    })();

This is incorrect, as the name is shadowed inside the function.  It should
instead rename these two:

    (function(){
        function _foo_() {
            var foo = 5;
            console.log(foo);
        }
        _foo_();
    })();

This patch fixes this.