### PR TITLE
Indent arrays correctly when they contain for loops.

### DIFF
--- a/js2-old-indent.el
+++ b/js2-old-indent.el
@@ -351,8 +351,13 @@ In particular, return the buffer position of the first `for' kwd."
             (if (and (> end (point)) ; not empty literal
                      (re-search-forward "[^,]]* \\(for\\) " end t)
                      ;; not inside comment or string literal
-                     (let ((state (parse-partial-sexp bracket (point))))
-                       (not (or (nth 3 state) (nth 4 state)))))
+                     (let ((bracket-state (parse-partial-sexp bracket bracket))
+                           (state (parse-partial-sexp bracket (point))))
+                       (and
+                        (not (nth 3 state))
+                        (not (nth 4 state))
+                        (eq (nth 0 state)
+                            (1+ (nth 0 state))))))
                 (match-beginning 1))))))))
 
 (defun js2-array-comp-indentation (parse-status for-kwd)


### PR DESCRIPTION
The "js2-indent-in-array-comp" function attempts to detect array
comprehensions, which are described on MDN here:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions

It is mildly over-eager, and causes the following code to be indented
like so:

```
var x = [
  function () {
    for (var i; i < 10; i++) {
    }
  },
    ];
```

With the closing bracket of the array indented to the same level as
the `for` statement that happens to be inside the array.

This patch helps prevent that, by checking that the paren depth of the
for loop is exactly one plus the paren depth of the containing array.