### PR TITLE
Use regular forward-sexp when inside strings

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12405,6 +12405,8 @@ move backward across N balanced expressions."
     (let (forward-sexp-function
           node (start (point)) pos lp rp child)
       (cond
+       ((js2-string-node-p (js2-node-at-point))
+        (forward-sexp arg))
        ;; backward-sexp
        ;; could probably make this better for some cases:
        ;;  - if in statement block (e.g. function body), go to parent

--- a/tests/navigation.el
+++ b/tests/navigation.el
@@ -58,3 +58,35 @@
 
 (ert-deftest js2-jump-to-property-object-property ()
   (js2-navigation-helper "aObject.value = {prop:1};aObject.value.prop" 18))
+
+
+;; forward-sexp
+
+(defun js2-test-forward-sexp (pre-point skipped after-sexp)
+  "Test `js2-mode-forward-sexp'.
+The test buffer's contents are set to the concatenation of
+PRE-POINT, SKIPPED, and AFTER-SEXP.  Point is placed after
+PRE-POINT, and `forward-sexp' is called.  Then point should be
+after SKIPPED."
+  (with-temp-buffer
+    (insert pre-point skipped after-sexp)
+    (js2-mode)
+    (goto-char (1+ (length pre-point)))
+    (forward-sexp)
+    (should (= (point) (+ 1 (length pre-point) (length skipped))))))
+
+(ert-deftest js2-forward-sexp-skip-semi ()
+  "Ensure expr-stmt-nodes' semicolons are skipped over."
+  (js2-test-forward-sexp "" "const s = 123;" ""))
+
+(ert-deftest js2-forward-sexp-inside-string ()
+  "Test forward sexp inside a string."
+  (js2-test-forward-sexp "const s = 'some " "(string contents)" " xyz';"))
+
+(ert-deftest js2-backward-sexp-inside-string ()
+  "Test backward sexp inside a string."
+  (with-temp-buffer
+    (insert "const s = 'some (string contents) ")
+    (save-excursion (insert "xyz';"))
+    (backward-sexp)
+    (should (= (point) 17))))


### PR DESCRIPTION
There's a strange inconsistency when using `forward-sexp` and `backward-sexp`: Moving backwards takes you to the beginning of the string, whereas moving forwards skips over a symbol or balanced pair.

This patch makes `js2` more consistent with other modes by disabling its custom `forward-sexp` inside strings.