### PR TITLE
Fix #495 Aggressively reparse in js2-mode-create-imenu-index if possible

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12577,8 +12577,11 @@ destroying the region selection."
         (goto-char (cl-cadadr e))))))
 
 (defun js2-mode-create-imenu-index ()
-  "Return an alist for `imenu--index-alist'."
-  ;; This is built up in `js2-parse-record-imenu' during parsing.
+  "Returns an alist for `imenu--index-alist'. Returns nil on first
+scan if buffer size > `imenu-auto-rescan-maxout'."
+  (when (and (not js2-mode-ast)
+             (<= (buffer-size) imenu-auto-rescan-maxout))
+      (js2-reparse))
   (when js2-mode-ast
     ;; if we have an ast but no recorder, they're requesting a rescan
     (unless js2-imenu-recorder


### PR DESCRIPTION
Aggressively reparse when AST is not available during first call to imenu-auto-rescan-maxout