### PR TITLE
allow testing for specific errors and add test for object property

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12747,7 +12747,8 @@ it marks the next defun after the ones already marked."
     (push (or (and names (pop names))
               (unless (and (js2-object-prop-node-p parent)
                            (eq node (js2-object-prop-node-left parent)))
-                node)) names)
+                node)
+              (error "Node is not a supported jump node")) names)
     (setq node-init (js2-search-scope node names))
 
     ;; todo: display list of results in buffer

--- a/tests/navigation.el
+++ b/tests/navigation.el
@@ -22,15 +22,20 @@
 (require 'ert)
 (require 'js2-mode)
 
-(cl-defun js2-navigation-helper (buffer-content &optional expected-point (point-offset 1))
+(cl-defun js2-navigation-helper (buffer-content &optional expected-point (point-offset 1) expected-error-msg)
   (with-temp-buffer
     (insert buffer-content)
-    (let ((start-point (or (- (point) point-offset))))
+    (let ((start-point (or (- (point) point-offset)))
+          actual-error-msg)
       (js2-mode)
       (goto-char start-point)
-      (ignore-errors (js2-jump-to-definition))
+      (if expected-error-msg
+          (setq actual-error-msg
+                (cadr (should-error (js2-jump-to-definition) :type 'error)))
+        (js2-jump-to-definition))
       (print (format "%d %d" (point) start-point))
-      (should (= (point) (or expected-point start-point))))))
+      (should (= (point) (or expected-point start-point)))
+      (should (string= actual-error-msg expected-error-msg)))))
 
 (ert-deftest js2-jump-to-var ()
   (js2-navigation-helper "var soup = 2; soup" 5))
@@ -45,7 +50,8 @@
   (js2-navigation-helper "var aObject = {prop1: 3, prop2: \"hello\"}; aObject.prop1" 16))
 
 (ert-deftest js2-no-jump-to-object-property ()
-  (js2-navigation-helper "var aObject = {prop1: 3, prop2: \"hello\"}; anotherObject.prop1"))
+  (js2-navigation-helper "var aObject = {prop1: 3, prop2: \"hello\"}; anotherObject.prop1"
+                         61 1 "No jump location found"))
 
 (ert-deftest js2-jump-to-nested-property ()
   (js2-navigation-helper "var aObject = {prop1: {prop2: { prop3: 4}}}; aObject.prop1.prop2.prop3" 33))
@@ -58,6 +64,15 @@
 
 (ert-deftest js2-jump-to-property-object-property ()
   (js2-navigation-helper "aObject.value = {prop:1};aObject.value.prop" 18))
+
+(ert-deftest js2-jump-to-function-definition-inside-object-value ()
+  (js2-navigation-helper
+   "function aFunction(p1, p2) {return p1+p2}; module.exports = {aFunction:aFunction};" 1 6))
+
+(ert-deftest js2-no-jump-to-function-definition-object-property ()
+  (js2-navigation-helper
+   "function aFunction(p1, p2) {return p1+p2}; module.exports = {aFunction:aFunction};"
+   67 16 "Node is not a supported jump node"))
 
 
 ;; forward-sexp


### PR DESCRIPTION
This commit changes `js2-navigation-helper` to detect a specific error message thrown by `js2-jump-to-definition` rather than running it under `ignore-errors`.

Changing `js2-navigation-helper` exposes a bug on line 12751;  attempting to jump from an object property literal means that neither predicate on lines 12748, 12749 are true and so `js2-search-scope` is called with `names == '(nil)`.