### PR TITLE
Use JSX highlighting and indentation added in Emacs 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ The stable versions are hosted at [GNU ELPA](http://elpa.gnu.org/)
 You can also install the latest development version from
 [MELPA](https://melpa.org/#/getting-started).
 
+JSX
+===
+
+Full support for highlighting and indenting of JSX is available in Emacs 27.
+Eventually it can be downloaded [here](https://www.gnu.org/software/emacs/);
+until it’s available there, you can install a snapshot of the Emacs master
+branch:
+
+```
+git clone https://git.savannah.gnu.org/git/emacs.git
+cd emacs
+./autogen.sh
+./configure
+make
+make install
+```
+
+Otherwise, in Emacs 26 and earlier, you can use `js2-jsx-mode` for rudimentary
+JSX indentation support (only).
+
 Emacs 22 and 23
 ===============
 

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -11715,7 +11715,7 @@ Selecting an error will jump it to the corresponding source-buffer error.
     (defun js-jsx--syntax-propertize-tag (_end))
     (defun js-use-syntactic-mode-name ())))
 
-;; In Emacs >=27, this is needed for JSX indentation.
+;; In Emacs >=27, this is needed for JSX indentation and highlighting.
 (defun js2-syntax-propertize (start end)
   "Apply syntax properties from START to END."
   (goto-char start)
@@ -11725,7 +11725,7 @@ Selecting an error will jump it to the corresponding source-buffer error.
     ("<" (0 (ignore (if js-jsx-syntax (js-jsx--syntax-propertize-tag end))))))
    (point) end))
 
-;; In Emacs >=27, this is needed for JSX font-locking.
+;; In Emacs >=27, this is needed for JSX highlighting.
 (defconst js2--font-lock-keywords
   `(,@js-jsx--font-lock-keywords)
   "Font lock keywords for `js2-mode'; see `font-lock-keywords'.")

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -11704,7 +11704,7 @@ Selecting an error will jump it to the corresponding source-buffer error.
         (message msg))))))
 
 ;;;###autoload
-(define-derived-mode js2-mode js-mode "Javascript-IDE"
+(define-derived-mode js2-mode js-mode "JavaScript-IDE"
   "Major mode for editing JavaScript code."
   (set (make-local-variable 'max-lisp-eval-depth)
        (max max-lisp-eval-depth 3000))

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -11705,15 +11705,6 @@ Selecting an error will jump it to the corresponding source-buffer error.
         (goto-char pos)
         (message msg))))))
 
-;; These are not yet defined in Emacs versions prior to 27;
-;; prevent compiler warnings when using them:
-(defvar js-jsx-syntax)
-(defvar js-jsx--font-lock-keywords)
-(defvar js-jsx--text-properties)
-(declare-function js-jsx-enable "js" ())
-(declare-function js-jsx--syntax-propertize-tag "js" (end))
-(declare-function js-use-syntactic-mode-name "js" ())
-
 ;; In Emacs >=27, this is needed for JSX indentation and highlighting.
 (defun js2-syntax-propertize (start end)
   "Apply syntax properties from START to END."

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -49,7 +49,7 @@
 ;;
 ;; To install it as your major mode for JavaScript editing:
 
-;;   (add-to-list 'auto-mode-alist '("\\.js\\'" . js2-mode))
+;;   (add-to-list 'auto-mode-alist '("\\.jsx?\\'" . js2-mode))
 
 ;; Alternatively, to install it as a minor mode just for JavaScript linting,
 ;; you must add it to the appropriate major-mode hook.  Normally this would be:
@@ -60,8 +60,10 @@
 
 ;;   (add-to-list 'interpreter-mode-alist '("node" . js2-mode))
 
-;; Support for JSX is available via the derived mode `js2-jsx-mode'.  If you
-;; also want JSX support, use that mode instead:
+;; Support for JSX is also available.  In Emacs 27, support for the syntax will
+;; be automatically enabled in buffers using it and in ".jsx" files.  For Emacs
+;; versions prior to 27, support is only available via the derived mode
+;; `js2-jsx-mode'; if you want JSX support in Emacs <27, use that mode instead:
 
 ;;   (add-to-list 'auto-mode-alist '("\\.jsx?\\'" . js2-jsx-mode))
 ;;   (add-to-list 'interpreter-mode-alist '("node" . js2-jsx-mode))
@@ -11761,14 +11763,14 @@ Selecting an error will jump it to the corresponding source-buffer error.
     ;; Schedule parsing for after when the mode hooks run.
     (js2-mode-reset-timer)))
 
-;; We may eventually want js2-jsx-mode to derive from js-jsx-mode, but that'd be
-;; a bit more complicated and it doesn't net us much yet.
 ;;;###autoload
 (define-derived-mode js2-jsx-mode js2-mode "JSX-IDE"
-  "Major mode for editing JSX code.
+  "Major mode for editing JavaScript+JSX code.
 
-To customize the indentation for this mode, set the SGML offset
-variables (`sgml-basic-offset' et al) locally, like so:
+This is like `js-jsx-mode', which see.
+
+In Emacs versions prior to 27, customize indentation by setting
+`sgml-basic-offset' locally, like so:
 
   (defun set-jsx-indentation ()
     (setq-local sgml-basic-offset js2-basic-offset))

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -11705,15 +11705,14 @@ Selecting an error will jump it to the corresponding source-buffer error.
         (goto-char pos)
         (message msg))))))
 
-(eval-and-compile
-  (when (version< emacs-version "27.0")
-    ;; Prevent compilation errors:
-    (defvar js-jsx-syntax nil)
-    (defconst js-jsx--font-lock-keywords nil)
-    (defvar js-jsx--text-properties nil)
-    (defun js-jsx-enable ())
-    (defun js-jsx--syntax-propertize-tag (_end))
-    (defun js-use-syntactic-mode-name ())))
+;; These are not yet defined in Emacs versions prior to 27;
+;; prevent compiler warnings when using them:
+(defvar js-jsx-syntax)
+(defvar js-jsx--font-lock-keywords)
+(defvar js-jsx--text-properties)
+(declare-function js-jsx-enable "js" ())
+(declare-function js-jsx--syntax-propertize-tag "js" (end))
+(declare-function js-use-syntactic-mode-name "js" ())
 
 ;; In Emacs >=27, this is needed for JSX indentation and highlighting.
 (defun js2-syntax-propertize (start end)

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -11750,6 +11750,11 @@ Selecting an error will jump it to the corresponding source-buffer error.
   (when js2-include-jslint-declaration-externs
     (add-hook 'js2-post-parse-callbacks 'js2-apply-jslint-declaration-externs nil t))
 
+  ;; In Emacs >=27, in order to see enabled syntaxes (like “[JSX]”) in the
+  ;; modeline, we need to first call this function.
+  (when (fboundp 'js-use-syntactic-mode-name)
+    (js-use-syntactic-mode-name))
+
   (run-hooks 'js2-init-hook)
 
   (let ((js2-idle-timer-delay 0))
@@ -11768,7 +11773,12 @@ variables (`sgml-basic-offset' et al) locally, like so:
   (defun set-jsx-indentation ()
     (setq-local sgml-basic-offset js2-basic-offset))
   (add-hook \\='js2-jsx-mode-hook #\\='set-jsx-indentation)"
-  (set (make-local-variable 'indent-line-function) #'js2-jsx-indent-line))
+  (if (version< emacs-version "27.0")
+      (set (make-local-variable 'indent-line-function) #'js2-jsx-indent-line)
+    (js-jsx-enable)
+    ;; Use the standard name because a syntactic part will be appended.
+    (setq mode-name "JavaScript-IDE")
+    (js-use-syntactic-mode-name)))
 
 (defun js2-mode-exit ()
   "Exit `js2-mode' and clean up."


### PR DESCRIPTION
The `master` branch of Emacs now provides support for highlighting JSX, greatly improves the current JSX indentation support, and automatically detects the use of JSX (without needing to enter `js-jsx-mode`).  These changes allow js2-mode to tap into these improvements when using Emacs on the `master` branch, or eventually in version 27.

Fixes #140, #330, #389, #411, #451, #459, #462, #482, #490

~~I was hoping this would address #409, but I think we may have a little more work to do for that.  Indentation is right in js-mode, but I think js2-mode is clearing the `syntax-table` text property needed to prevent JSXText from introducing unterminated strings.  To solve this I will probably provide more changes (here or in another PR) that re-adds the `syntax-table` property here after it is cleared elsewhere.~~

[As noted below](https://github.com/mooz/js2-mode/pull/523#issuecomment-481984063), this now also fixes #409.