### PR TITLE
Add support for BigInt and 1234n/1234N constants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # History of user-visible changes
 
+## 2019-10-14
+* Added support for BigInt and 1234n or 1234N constants.
+
 ## Next
 
 * Emacs 27 now provides improved JSX indentation support, along with

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -216,7 +216,7 @@ are enabled, these will also be included.")
 
 (defvar js2-harmony-externs
   (mapcar 'symbol-name
-          '(Map Promise Proxy Reflect Set Symbol WeakMap WeakSet))
+          '(BigInt Map Promise Proxy Reflect Set Symbol WeakMap WeakSet))
   "ES6 externs.  If `js2-include-browser-externs' is enabled and
 `js2-language-version' is sufficiently high, these will be included.")
 
@@ -6047,6 +6047,10 @@ its relevant fields and puts it into `js2-ti-tokens'."
                         (js2-add-to-string c)
                         (setq c (js2-get-char))
                         while (js2-digit-p c))))
+           ;; BigInt constant (1234n or 1234N)
+           (when (and (memq c '(?n ?N))
+                      (>= js2-language-version 200))
+             (setq c (js2-get-char)))
            (js2-unget-char)
            (let ((str (js2-set-string-from-buffer token)))
              (setf (js2-token-number token) (js2-string-to-number str base)


### PR DESCRIPTION
The `BigInt` extern and support for 1234n and 1234N constants conditionalized for Harmony (JS language version >= 200).