### PR TITLE
Support private fields for classes with #-prefix

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -5587,7 +5587,7 @@ Returns nil and consumes nothing if TEST is not the next character."
   "Is C a valid start to an ES5 Identifier?
 See http://es5.github.io/#x7.6"
   (or
-   (memq c '(?$ ?_))
+   (memq c '(?$ ?_ ?#))
    (memq (get-char-code-property c 'general-category)
          ;; Letters
          '(Lu Ll Lt Lm Lo Nl))))

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -161,6 +161,9 @@ the test."
 (js2-deftest-parse parse-property-access-when-not-keyword
   "A.foo = 3;")
 
+(js2-deftest-parse parse-property-access-when-not-keyword
+  "A.#foo = 3;")
+
 (js2-deftest-parse parse-property-access-when-keyword
   "A.in = 3;"
   :bind ((js2-allow-keywords-as-property-names t)))
@@ -975,6 +978,10 @@ the test."
 (js2-deftest-parse parse-class-public-field-with-init
   "class C {\n  x = 42;\n  y = 24;\n  \"z\" = 1\n  456 = 789\n}"
   :reference "class C {\n  x = 42\n  y = 24\n  \"z\" = 1\n  456 = 789\n}")
+
+(js2-deftest-parse parse-class-private-field-with-init
+  "class C {\n  #x = 42;\n  #y = 24;\n}"
+  :reference "class C {\n  #x = 42\n  #y = 24\n}")
 
 (js2-deftest-parse parse-class-public-field-no-init
   "class C {\n  x\n  y\n  \"z\"\n  456\n}")


### PR DESCRIPTION
With this change the parser no longer treats private fields in Javascript classes (https://github.com/tc39/proposal-class-fields) as errors.