### PR TITLE
Use type face for class

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -10887,7 +10887,7 @@ If ONLY-OF-P is non-nil, only the 'for (foo of bar)' form is allowed."
         (_ (js2-must-match-name "msg.unnamed.class.stmt"))
         (name (js2-create-name-node t)))
     (js2-set-face (js2-node-pos name) (js2-node-end name)
-                  'font-lock-function-name-face 'record)
+                  'font-lock-type-face 'record)
     (let ((node (js2-parse-class pos 'CLASS_STATEMENT name)))
       (js2-record-imenu-functions node name)
       (js2-define-symbol js2-FUNCTION


### PR DESCRIPTION
Because now we can, and it's consistent with how every other major modes for languages that have classes.