### PR TITLE
Fix ‘huge-hex’ test for newer Emacsen.

### DIFF
--- a/tests/parser.el
+++ b/tests/parser.el
@@ -586,7 +586,8 @@ the test."
 
 (js2-deftest-parse decimal-starting-with-zero "081;" :reference "81;")
 
-(js2-deftest-parse huge-hex "0x0123456789abcdefABCDEF;" :reference "-1;")
+(js2-deftest-parse huge-hex "0x0123456789abcdefABCDEF;"
+  :reference (if (> emacs-major-version 26) "1375488932539311409843695;" "-1;"))
 
 (js2-deftest-parse octal-without-o "071;" :reference "57;")
 


### PR DESCRIPTION
Starting with Emacs 27, we have big integers, so the huge hexadecimal value is
parsed exactly.