### PR TITLE
Prefix an unused argument with an underscore.

### DIFF
--- a/js2-old-indent.el
+++ b/js2-old-indent.el
@@ -480,7 +480,7 @@ indentation is aligned to that column."
         (+ 1 (current-column))
       0)))
 
-(defun js2-indent-line (&optional bounce-backwards)
+(defun js2-indent-line (&optional _bounce-backwards)
   "Indent the current line as JavaScript source text."
   (interactive)
   (let (parse-status offset


### PR DESCRIPTION
This avoids a byte-compile warning.