### PR TITLE
Use Eask for CI?

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '16'
 
     - uses: emacs-eask/setup-eask@master
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    if: github.repository_owner == 'mooz'
+    #if: github.repository_owner == 'mooz'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,19 +15,30 @@ on:
 jobs:
   test:
     if: github.repository_owner == 'mooz'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         emacs_version:
           - 25.1
           - 26.3
           - 27.2
+          - 28.1
           - snapshot
     steps:
     - name: Set up Emacs
-      uses: purcell/setup-emacs@master
+      uses: jcs090218/setup-emacs@master
       with:
         version: ${{matrix.emacs_version}}
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
 
     - name: Check out the source code
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,4 +45,4 @@ jobs:
     - name: Test the project
       run: |
         emacs --version
-        make test
+        make ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    #if: github.repository_owner == 'mooz'
+    if: github.repository_owner == 'mooz'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -44,5 +44,4 @@ jobs:
 
     - name: Test the project
       run: |
-        emacs --version
         make ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,13 @@ on:
 
 jobs:
   test:
-    #if: github.repository_owner == 'mooz'
+    if: github.repository_owner == 'mooz'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs_version:
-          - 25.1
           - 26.3
           - 27.2
           - 28.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.elc
+.eask
+/dist

--- a/Eask
+++ b/Eask
@@ -8,3 +8,5 @@
 
 (depends-on "emacs" "24.1")
 (depends-on "cl-lib")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Eask
+++ b/Eask
@@ -1,0 +1,9 @@
+(package "js2-mode"
+         "20211229"
+         "Improved JavaScript editing mode")
+
+(package-file "js2-mode.el")
+
+(source "gnu")
+
+(depends-on "emacs" "24.1")

--- a/Eask
+++ b/Eask
@@ -4,6 +4,8 @@
 
 (package-file "js2-mode.el")
 
+(files "*.el")
+
 (source "gnu")
 
 (depends-on "emacs" "24.1")

--- a/Eask
+++ b/Eask
@@ -7,3 +7,4 @@
 (source "gnu")
 
 (depends-on "emacs" "24.1")
+(depends-on "cl-lib")

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,27 @@
 # -*- Makefile -*-
 
 EMACS = emacs
+EASK = eask
 
-# Compile with noninteractive and relatively clean environment.
-BATCHFLAGS = -batch -Q
+ci: build compile checkdoc lint test
 
-SRCS = js2-mode.el js2-imenu-extras.el
+build:
+	$(EASK) package
+	$(EASK) install
 
-TESTS = $(wildcard tests/*.el)
-
-OBJS = $(SRCS:.el=.elc) $(TESTS:.el=.elc)
-
-%.elc: %.el
-	${EMACS} $(BATCHFLAGS) -L . -f batch-byte-compile $^
-
-all: $(OBJS)
+compile: 
+	$(EASK) compile
 
 clean:
-	-rm -f $(OBJS)
+    $(EASK) clean-all
 
-test:	all
-	${EMACS} $(BATCHFLAGS) -L . \
-	  $(addprefix -l ,$(OBJS)) \
-	  -f ert-run-tests-batch-and-exit
+test:
+	$(EASK) install-deps --dev
+	$(EASK) ert ./tests/*.el
+
+checkdoc:
+    $(EASK) checkdoc
+
+# package-lint
+lint:
+    $(EASK) lint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 
-EMACS = emacs
-EASK = eask
+EMACS ?= emacs
+EASK ?= eask
 
 ci: build compile checkdoc lint test
 
@@ -20,8 +20,8 @@ test:
 	$(EASK) ert ./tests/*.el
 
 checkdoc:
-    $(EASK) checkdoc
+	$(EASK) checkdoc
 
 # package-lint
 lint:
-    $(EASK) lint
+	$(EASK) lint

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 EMACS ?= emacs
 EASK ?= eask
 
-ci: build compile checkdoc lint test
+# TODO: add lint?
+ci: build compile checkdoc test
 
 build:
 	$(EASK) package

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ compile:
 	$(EASK) compile
 
 clean:
-    $(EASK) clean-all
+	$(EASK) clean-all
 
 test:
 	$(EASK) install-deps --dev


### PR DESCRIPTION
This patch does the following:

#### In `.github/workflow/emacs.yml`

* Use `jcs090218/setup-emacs` instead of `purcell/setup-emacs`
  - Add retry capability to prevent failure on Emacs' installation
  - Support windows
* Add setup-node (`16`)
* Add `setup-eask`
* Add test for Emacs `28.1`, drop Emacs `25.1` (Eask must use `26.1` or above)
* Add tests on `Windows` and `macOS`

#### In `Makefile` (newly added)

* Replace Emacs command-line arguments `emacs --batch ...` with just `eask <command>`

> Edit:

* Add `make checkdoc`
* Add `make lint` (but left unused for now)

#### Others

* Add `Eask`-file

---

This is totally optional, I think the solution may not be ideal since this drops the test on Emacs `25.1`. :(

Let me know what you think? Hope this could make CI on Emacs a lot easier! :)