### PR TITLE
Remove the correct hook in js2-minor-mode-exit

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -11756,7 +11756,7 @@ highlighting features of `js2-mode'."
 (defun js2-minor-mode-exit ()
   "Turn off `js2-minor-mode'."
   (setq next-error-function nil)
-  (remove-hook 'after-change-functions #'js2-mode-edit t)
+  (remove-hook 'after-change-functions #'js2-minor-mode-edit t)
   (remove-hook 'change-major-mode-hook #'js2-minor-mode-exit t)
   (when js2-mode-node-overlay
     (delete-overlay js2-mode-node-overlay)


### PR DESCRIPTION
The `js2-minor-mode-enter` adds `js2-minor-mode-edit` to `after-change-functions`. Contrary the `js2-minor-mode-exit` removes `js2-mode-edit` which had not been added to the list.

Without that, after enabling `js2-minor-mode` the `js-lint` remains enabled even when the mode exits.

I decided to go straight for a PR, as the issue looks like an obvious mistake, at first glance. Should that be not the case, apologies, for a naïve approach.