### PR TITLE
Support top-level await

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* Support top-level await
+  ([#593](https://github.com/mooz/js2-mode/issues/593)).
 * Fix for escaping inside template literal
   ([#592](https://github.com/mooz/js2-mode/issues/592)).
 

--- a/js2-mode.el
+++ b/js2-mode.el
@@ -8064,7 +8064,7 @@ string is NAME.  Returns nil and keeps current token otherwise."
                nil)
            ;; The parse was successful, so process and return the "await".
            (js2-record-face 'font-lock-keyword-face current-token)
-           (unless (js2-inside-async-function)
+           (unless (or (js2-inside-async-function) (equal js2-nesting-of-function 0))
              (js2-report-error "msg.bad.await" nil
                                beg (- end beg)))
            pn))))

--- a/tests/parser.el
+++ b/tests/parser.el
@@ -572,6 +572,9 @@ the test."
 (js2-deftest-parse await-inside-array-is-ok
                    "async function foo() {\n  var results = [await bar(), await baz()];\n}")
 
+(js2-deftest-parse await-top-level-is-ok
+                   "await bar();")
+
 (js2-deftest-parse await-inside-non-async-function-is-not-ok
                    "function foo() {\n  await bar();\n}"
                    :syntax-error "await")


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await

This is part of ECMAScript 2022: https://en.wikipedia.org/wiki/ECMAScript#ES2022