### PR TITLE
Make js2-beginning-of-defun skip comments

### DIFF
--- a/js2-mode.el
+++ b/js2-mode.el
@@ -12867,7 +12867,7 @@ to beginning of previous script-level element.
 With ARG N, do that N times. If N is negative, move forward."
   (setq arg (or arg 1))
   (if (cl-plusp arg)
-      (let ((parent (js2-node-parent-script-or-fn (js2-node-at-point))))
+      (let ((parent (js2-node-parent-script-or-fn (js2-node-at-point nil t))))
         (when (cond
                ((js2-function-node-p parent)
                 (goto-char (js2-node-abs-pos parent)))


### PR DESCRIPTION
Make js2-beginning-of-defun skip comments. Fixes mark-defun bug for js2-mode when invoked inside a comment.